### PR TITLE
feat: 支持调整 R2V 提示词框高度

### DIFF
--- a/web/js/minimax_i18n.js
+++ b/web/js/minimax_i18n.js
@@ -58,6 +58,7 @@ const ZH = {
     "tooltip.dragR2vOrder": "拖动：调整素材组顺序",
     "tooltip.dragPromptGroupOrder": "拖动：调整提示词组顺序",
     "tooltip.dragSegmentOrder": "拖动：调整片段顺序",
+    "tooltip.promptEditorResize": "上下拖动调整提示词框高度；方向键可微调",
 
     "output.totalDurationSec": "总时长（秒）",
     "output.resolution": "输出分辨率",
@@ -453,6 +454,7 @@ const EN = {
     "tooltip.dragR2vOrder": "Drag: reorder asset groups",
     "tooltip.dragPromptGroupOrder": "Drag: reorder prompt groups",
     "tooltip.dragSegmentOrder": "Drag: reorder segments",
+    "tooltip.promptEditorResize": "Drag vertically to resize the prompt editor; use arrow keys for fine adjustment",
 
     "output.totalDurationSec": "Total duration (sec)",
     "output.resolution": "Output resolution",

--- a/web/js/minimax_prompt_mentions.js
+++ b/web/js/minimax_prompt_mentions.js
@@ -49,6 +49,22 @@ const MENTION_STYLES = `
 }
 .bd-token-editor:focus{border-color:#4a7a5a;box-shadow:0 0 0 1px rgba(79,255,143,.18)}
 .bd-token-editor:empty:before{content:attr(data-placeholder);color:#666;pointer-events:none}
+.bd-token-resize-handle{
+  position:absolute;left:50%;bottom:0;z-index:4;width:96px;max-width:40%;height:18px;
+  transform:translateX(-50%);display:flex;align-items:flex-end;justify-content:center;
+  padding:0;border:0;background:transparent;outline:none;border-radius:8px 8px 0 0;
+  cursor:ns-resize;touch-action:none;user-select:none
+}
+.bd-token-resize-handle::after{
+  content:"";width:54px;max-width:72%;height:3px;margin-bottom:3px;border-radius:999px;
+  background:#52665a;box-shadow:0 -4px 0 rgba(82,102,90,.65)
+}
+.bd-token-resize-handle:hover::after,
+.bd-token-resize-handle:focus-visible::after,
+.bd-token-wrap.bd-token-resizing .bd-token-resize-handle::after{
+  background:#4fff8f;box-shadow:0 -4px 0 rgba(79,255,143,.45)
+}
+body.bd-token-resizing{cursor:ns-resize!important;user-select:none!important}
 .bd-rv2v-layout .bd-token-editor,.bd-v2v-layout .bd-token-editor{
   min-height:220px;background:#101010;border-color:#2e2e2e;border-radius:8px;padding:10px;font-size:12px;line-height:1.45
 }
@@ -556,6 +572,98 @@ function positionMenu(menu, editor) {
     menu.style.top = `${Math.round(top)}px`;
 }
 
+/**
+ * Native CSS resize handles are unreliable inside ComfyUI's transformed canvas.
+ * This explicit grip converts viewport pointer movement back into the editor's
+ * unscaled CSS height, so dragging remains accurate at every canvas zoom level.
+ */
+function installTokenResizeHandle(wrap, editor) {
+    if (!wrap || !editor || wrap.querySelector(":scope > .bd-token-resize-handle")) return;
+
+    const handle = document.createElement("button");
+    handle.type = "button";
+    handle.className = "bd-token-resize-handle";
+    handle.dataset.role = "prompt-resize-handle";
+    handle.setAttribute("aria-label", t("tooltip.promptEditorResize"));
+    handle.dataset.i18nTitle = "tooltip.promptEditorResize";
+    handle.title = t("tooltip.promptEditorResize");
+    wrap.appendChild(handle);
+
+    const applyHeight = (height, minHeight = 96) => {
+        const nextHeight = Math.max(minHeight, Math.round(height));
+        editor.style.height = `${nextHeight}px`;
+        wrap.style.height = `${nextHeight}px`;
+    };
+
+    handle.addEventListener("keydown", (event) => {
+        if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+        event.preventDefault();
+        event.stopPropagation();
+        const computed = getComputedStyle(editor);
+        const current = Number.parseFloat(computed.height) || editor.offsetHeight || 96;
+        const minHeight = Number.parseFloat(computed.minHeight) || 96;
+        const step = event.shiftKey ? 80 : 24;
+        applyHeight(current + (event.key === "ArrowDown" ? step : -step), minHeight);
+    });
+
+    handle.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+    });
+
+    handle.addEventListener("pointerdown", (event) => {
+        if (event.button !== 0) return;
+        event.preventDefault();
+        event.stopPropagation();
+
+        const computed = getComputedStyle(editor);
+        const rect = editor.getBoundingClientRect();
+        const startHeight = Number.parseFloat(computed.height) || editor.offsetHeight || 96;
+        const minHeight = Number.parseFloat(computed.minHeight) || 96;
+        const scaleY = rect.height > 0 ? rect.height / startHeight : 1;
+        const startY = event.clientY;
+        const pointerId = event.pointerId;
+
+        wrap.classList.add("bd-token-resizing");
+        document.body.classList.add("bd-token-resizing");
+        try {
+            handle.setPointerCapture(pointerId);
+        } catch {
+            /* Window listeners below keep dragging active without pointer capture. */
+        }
+
+        const onMove = (moveEvent) => {
+            if (moveEvent.pointerId !== pointerId) return;
+            moveEvent.preventDefault();
+            moveEvent.stopPropagation();
+            applyHeight(
+                startHeight + (moveEvent.clientY - startY) / Math.max(scaleY, 0.01),
+                minHeight
+            );
+        };
+
+        const stop = (endEvent) => {
+            if (endEvent.pointerId !== pointerId) return;
+            endEvent.preventDefault();
+            endEvent.stopPropagation();
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", stop);
+            window.removeEventListener("pointercancel", stop);
+            wrap.classList.remove("bd-token-resizing");
+            document.body.classList.remove("bd-token-resizing");
+            try {
+                handle.releasePointerCapture(pointerId);
+            } catch {
+                /* Ignore when capture already ended. */
+            }
+        };
+
+        window.addEventListener("pointermove", onMove, { passive: false });
+        window.addEventListener("pointerup", stop);
+        window.addEventListener("pointercancel", stop);
+    });
+}
+
 function ensureTokenShell(textarea) {
     if (textarea.dataset.tokenShell === "1" && textarea.__bdTokenEditor) {
         return textarea.__bdTokenEditor;
@@ -583,6 +691,10 @@ function ensureTokenShell(textarea) {
         editor.classList.add(cls);
     }
     wrap.appendChild(editor);
+    // R2V uses the growable card/list layout; other modes keep their existing flex sizing.
+    if (textarea.closest(".bd-batch-r2v")) {
+        installTokenResizeHandle(wrap, editor);
+    }
     textarea.__bdTokenEditor = editor;
     textarea.__bdTokenWrap = wrap;
 

--- a/web/js/minimax_timeline.js
+++ b/web/js/minimax_timeline.js
@@ -550,20 +550,27 @@ const STYLES = `
 .bd-wrap.bd-batch-fill .bd-run-status{flex:0 0 auto;margin-top:0;flex-shrink:0}
 /* Fixed min so progress text wrap does not change node chrome height every tick. */
 .bd-run-status{min-height:52px;box-sizing:border-box}
-/* Solo material group (class set by syncBatchPanelFillHeight): card fills the list. */
+/* Solo material group fills the viewport by default, but may grow beyond it when
+   the user drags the rich prompt editor. The list then scrolls instead of
+   clipping the editor or forcing its height back to auto. */
 .bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo>.bd-batch-card{flex:1 1 auto;min-height:0;align-self:stretch}
-.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo>.bd-batch-card.bd-batch-r2v{display:flex;flex-direction:column}
-.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-batch-r2v-body{flex:1 1 auto;min-height:280px;max-height:100%;align-self:stretch}
-.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-batch-r2v-main{flex:1 1 auto;min-height:0;height:auto;max-height:100%}
-.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-batch-prompts{flex:1 1 auto;min-height:0;max-height:100%;overflow:hidden}
-.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-token-wrap,
-.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-token-editor{
-  flex:1 1 auto;min-height:200px;max-height:100%;height:auto!important;overflow:auto
+.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo>.bd-batch-card.bd-batch-r2v{
+  display:flex;flex-direction:column;flex:0 0 auto!important;min-height:100%;height:auto!important
 }
-.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo>.bd-batch-card.bd-batch-r2v .bd-token-wrap,
-.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo>.bd-batch-card.bd-batch-r2v .bd-token-editor,
-.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo>.bd-batch-card.bd-batch-r2v .bd-batch-prompts textarea{
-  max-height:100%
+.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-batch-r2v-body{
+  flex:0 0 auto;min-height:280px;max-height:none;align-self:stretch
+}
+.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-batch-r2v-main{
+  flex:0 0 auto;min-height:0;height:auto;max-height:none
+}
+.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-batch-prompts{
+  flex:0 0 auto;min-height:140px;max-height:none;overflow:visible
+}
+.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-token-wrap{
+  flex:0 0 auto;min-height:120px;max-height:none;height:auto;overflow:visible
+}
+.bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo .bd-token-editor{
+  flex:0 0 auto;min-height:120px;max-height:none;height:360px;overflow:auto;resize:vertical
 }
 .bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo>.bd-batch-card.bd-batch-plain,
 .bd-wrap.bd-batch-fill .bd-batch-list.bd-batch-solo>.bd-batch-card.bd-batch-source,


### PR DESCRIPTION
## 改动内容

- 为 R2V 素材组的富文本提示词框增加可见的纵向拖拽把手
- 按 ComfyUI 画布缩放比例换算拖拽距离，在缩放画布中仍能准确调整高度
- 解除单素材组布局对编辑框的固定高度与最大高度限制；编辑框增大后由素材组列表滚动承载
- 支持方向键微调，并补充中英文提示

## 背景

长结构化提示词在当前 R2V 单素材组布局中较拥挤。原有 CSS 虽声明了 resize: vertical，但后续的 height: auto !important、max-height: 100% 与固定卡片高度会覆盖或裁掉调整结果；原生缩放把手在 ComfyUI 的变换画布内也不稳定。

## 验证

- git diff --check
- node --check web/js/minimax_i18n.js
- node --check web/js/minimax_prompt_mentions.js
- node --check web/js/minimax_timeline.js
- 本地 ComfyUI 实测同一缩放逻辑：编辑框可从 360px 放大至 432px、缩小至 312px；指针拖拽可从 312px 放大至 428px 并缩回 312px
- 调整前后富文本内容与隐藏 textarea 的正式提示词值保持一致
- 编辑框增大后，外层素材组列表滚动高度随之增长；控制台无新增错误
- 已基于最新 main，并确认上游的长提示词重绘防抖与文本截断优化仍保留

仓库当前未配置 GitHub Actions 工作流。