### PR TITLE
fix: add drag-and-drop to r2v video/audio and i2v image slots

### DIFF
--- a/web/js/minimax_image_batch.js
+++ b/web/js/minimax_image_batch.js
@@ -2392,7 +2392,18 @@ function appendBatchCard(list, editor, seg, index, ctx) {
             media.className = "bd-batch-media";
             const src = document.createElement("div");
             src.className = "bd-batch-src";
-            renderSourceSlot(src, seg.genImage?.imageFile);
+            src.addEventListener("dragover", (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; });
+            src.addEventListener("drop", async (e) => {
+                e.preventDefault(); e.stopPropagation();
+                const file = e.dataTransfer.files?.[0];
+                if (file?.type?.startsWith("image/")) {
+                    try {
+                        const uploaded = await uploadMedia(file);
+                        seg.genImage = { imageFile: relPath(uploaded), fileName: file.name };
+                        editor.renderImageBatchGroups(); editor.commit();
+                    } catch (err) { console.error("Source drop failed:", err); }
+                }
+            });
             src.onclick = () => uploadSegSource(editor, index);
             media.appendChild(src);
             const pickSrc = document.createElement("button");

--- a/web/js/minimax_image_batch.js
+++ b/web/js/minimax_image_batch.js
@@ -1724,17 +1724,36 @@ function appendR2vMediaSections(card, seg, index, editor) {
         if (file?.type?.startsWith("video/")) {
             const seg = editor.timeline.segments[index];
             const existing = (seg.refVideos || []).filter(r => r && r.videoFile);
-            let next = 0;
-            while (existing.some(r => r && Number(r.index ?? r.slot) === next)) next++;
-            if (next >= 3) { alert("Máx 3 videos"); return; }
+            
+            // Detectar en qué slot se hizo el drop
+            const dropTarget = e.target.closest?.(".bd-batch-video");
+            let targetIndex = -1;
+            if (dropTarget) {
+                targetIndex = Number(dropTarget.dataset?.refIndex);
+            }
+            
+            // Si hay un target válido, usar ese slot (reemplazar si está ocupado)
+            let targetSlot = targetIndex >= 0 ? targetIndex : -1;
+            if (targetSlot < 0 || targetSlot >= 3) {
+                // Si no hay target válido, buscar el siguiente hueco libre
+                let next = 0;
+                while (existing.some(r => r && Number(r.index ?? r.slot) === next)) next++;
+                targetSlot = next;
+            }
+            
+            if (targetSlot >= 3) { alert("Máx 3 videos"); return; }
+            
             try {
                 const uploaded = await uploadMedia(file);
-                seg.refVideos = [...existing, { index: next, videoFile: relPath(uploaded), fileName: file.name, type: "input", subfolder: "" }];
+                // Reemplazar slot existente o añadir al targetSlot
+                const newVids = (seg.refVideos || []).filter(r => Number(r.index ?? r.slot) !== targetSlot);
+                newVids.push({ index: targetSlot, videoFile: relPath(uploaded), fileName: file.name, type: "input", subfolder: "" });
+                seg.refVideos = newVids;
                 editor.renderImageBatchGroups(); editor.commit();
             } catch (err) { console.error("Video drop failed:", err); }
         }
     });
-    if (vidSlots <= 0 && vidOffset > 0) {
+   if (vidSlots <= 0 && vidOffset > 0) {
         const empty = document.createElement("p");
         empty.className = "bd-r2v-slot-hint";
         empty.textContent = t("batch.r2v.noGroupVideoSlots");
@@ -1745,8 +1764,30 @@ function appendR2vMediaSections(card, seg, index, editor) {
             const ref = (seg.refVideos || []).find((r) => Number(r.index ?? r.slot) === abs);
             const slot = document.createElement("div");
             renderVideoSlot(slot, ref, abs, index, editor, { r2v: true });
+            slot.dataset.refIndex = String(abs);
+            slot.addEventListener("dragover", (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; });
+            slot.addEventListener("drop", async (e) => {
+                e.preventDefault(); e.stopPropagation();
+                const file = e.dataTransfer.files?.[0];
+                if (file?.type?.startsWith("video/")) {
+                    const seg = editor.timeline.segments[index];
+                    const existing = (seg.refVideos || []).filter(r => r && r.videoFile);
+                    
+                    // Reemplazar slot específico
+                    let targetSlot = abs;
+                    if (targetSlot >= 3) { alert("Máx 3 videos"); return; }
+                    
+                    try {
+                        const uploaded = await uploadMedia(file);
+                        // Reemplazar slot existente o añadir al targetSlot
+                        const newVids = (seg.refVideos || []).filter(r => Number(r.index ?? r.slot) !== targetSlot);
+                        newVids.push({ index: targetSlot, videoFile: relPath(uploaded), fileName: file.name, type: "input", subfolder: "" });
+                        seg.refVideos = newVids;
+                        editor.renderImageBatchGroups(); editor.commit();
+                    } catch (err) { console.error("Video drop failed:", err); }
+                }
+            });
             slot.onclick = (e) => {
-                if (e.type === 'drop') { e.preventDefault(); e.stopPropagation(); return; }
                 if (e.target.closest?.(".bd-r2v-play, .bd-r2v-dur, .bd-r2v-progress, .x, video, audio")) return;
                 if (ref && e.target.closest?.(".bd-r2v-thumb")) {
                     slot.querySelector(".bd-r2v-play")?.click();
@@ -1773,26 +1814,9 @@ function appendR2vMediaSections(card, seg, index, editor) {
             }
             : {},
     );
-    const audios = document.createElement("div");
+  const audios = document.createElement("div");
     audios.className = "bd-batch-audios";
-    audios.addEventListener("dragover", (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; });
-    audios.addEventListener("drop", async (e) => {
-        e.preventDefault(); e.stopPropagation();
-        const file = e.dataTransfer.files?.[0];
-        if (file?.type?.startsWith("audio/")) {
-            const seg = editor.timeline.segments[index];
-            const existing = (seg.refAudios || []).filter(r => r && r.audioFile);
-            let next = 0;
-            while (existing.some(r => r && Number(r.index ?? r.slot) === next)) next++;
-            if (next >= 3) { alert("Máx 3 audios"); return; }
-            try {
-                const uploaded = await uploadMedia(file);
-                seg.refAudios = [...existing, { index: next, audioFile: relPath(uploaded), fileName: file.name, type: "input", subfolder: "" }];
-                editor.renderImageBatchGroups(); editor.commit();
-            } catch (err) { console.error("Audio drop failed:", err); }
-        }
-    });
-    if (audSlots <= 0 && audOffset > 0) {
+  if (audSlots <= 0 && audOffset > 0) {
         const empty = document.createElement("p");
         empty.className = "bd-r2v-slot-hint";
         empty.textContent = t("batch.r2v.noGroupAudioSlots");
@@ -1803,8 +1827,30 @@ function appendR2vMediaSections(card, seg, index, editor) {
             const ref = (seg.refAudios || []).find((r) => Number(r.index ?? r.slot) === abs);
             const slot = document.createElement("div");
             renderAudioSlot(slot, ref, abs, index, editor, { r2v: true });
+            slot.dataset.refIndex = String(abs);
+            slot.addEventListener("dragover", (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; });
+            slot.addEventListener("drop", async (e) => {
+                e.preventDefault(); e.stopPropagation();
+                const file = e.dataTransfer.files?.[0];
+                if (file?.type?.startsWith("audio/")) {
+                    const seg = editor.timeline.segments[index];
+                    const existing = (seg.refAudios || []).filter(r => r && r.audioFile);
+                    
+                    // Reemplazar slot específico
+                    let targetSlot = abs;
+                    if (targetSlot >= 3) { alert("Máx 3 audios"); return; }
+                    
+                    try {
+                        const uploaded = await uploadMedia(file);
+                        // Reemplazar slot existente o añadir al targetSlot
+                        const newAudios = (seg.refAudios || []).filter(r => Number(r.index ?? r.slot) !== targetSlot);
+                        newAudios.push({ index: targetSlot, audioFile: relPath(uploaded), fileName: file.name, type: "input", subfolder: "" });
+                        seg.refAudios = newAudios;
+                        editor.renderImageBatchGroups(); editor.commit();
+                    } catch (err) { console.error("Audio drop failed:", err); }
+                }
+            });
             slot.onclick = (e) => {
-                if (e.type === 'drop') { e.preventDefault(); e.stopPropagation(); return; }
                 if (e.target.closest?.(".bd-r2v-play, .bd-r2v-dur, .bd-r2v-progress, .x, video, audio")) return;
                 if (ref && e.target.closest?.(".bd-r2v-thumb")) {
                     slot.querySelector(".bd-r2v-play")?.click();
@@ -2392,6 +2438,16 @@ function appendBatchCard(list, editor, seg, index, ctx) {
             media.className = "bd-batch-media";
             const src = document.createElement("div");
             src.className = "bd-batch-src";
+            
+            // Render the source image if it exists
+            if (seg.genImage?.imageFile) {
+                src.className += " has-img";
+                const img = document.createElement("img");
+                img.src = viewUrl(seg.genImage.imageFile);
+                img.alt = "";
+                src.appendChild(img);
+            }
+            
             src.addEventListener("dragover", (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; });
             src.addEventListener("drop", async (e) => {
                 e.preventDefault(); e.stopPropagation();
@@ -2400,6 +2456,15 @@ function appendBatchCard(list, editor, seg, index, ctx) {
                     try {
                         const uploaded = await uploadMedia(file);
                         seg.genImage = { imageFile: relPath(uploaded), fileName: file.name };
+                        
+                        // Render the uploaded image in the UI
+                        src.className = "bd-batch-src has-img";
+                        src.innerHTML = "";
+                        const img = document.createElement("img");
+                        img.src = viewUrl(uploaded);
+                        img.alt = "";
+                        src.appendChild(img);
+                        
                         editor.renderImageBatchGroups(); editor.commit();
                     } catch (err) { console.error("Source drop failed:", err); }
                 }

--- a/web/js/minimax_image_batch.js
+++ b/web/js/minimax_image_batch.js
@@ -1717,6 +1717,23 @@ function appendR2vMediaSections(card, seg, index, editor) {
     );
     const videos = document.createElement("div");
     videos.className = "bd-batch-videos";
+    videos.addEventListener("dragover", (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; });
+    videos.addEventListener("drop", async (e) => {
+        e.preventDefault(); e.stopPropagation();
+        const file = e.dataTransfer.files?.[0];
+        if (file?.type?.startsWith("video/")) {
+            const seg = editor.timeline.segments[index];
+            const existing = (seg.refVideos || []).filter(r => r && r.videoFile);
+            let next = 0;
+            while (existing.some(r => r && Number(r.index ?? r.slot) === next)) next++;
+            if (next >= 3) { alert("Máx 3 videos"); return; }
+            try {
+                const uploaded = await uploadMedia(file);
+                seg.refVideos = [...existing, { index: next, videoFile: relPath(uploaded), fileName: file.name, type: "input", subfolder: "" }];
+                editor.renderImageBatchGroups(); editor.commit();
+            } catch (err) { console.error("Video drop failed:", err); }
+        }
+    });
     if (vidSlots <= 0 && vidOffset > 0) {
         const empty = document.createElement("p");
         empty.className = "bd-r2v-slot-hint";
@@ -1729,6 +1746,7 @@ function appendR2vMediaSections(card, seg, index, editor) {
             const slot = document.createElement("div");
             renderVideoSlot(slot, ref, abs, index, editor, { r2v: true });
             slot.onclick = (e) => {
+                if (e.type === 'drop') { e.preventDefault(); e.stopPropagation(); return; }
                 if (e.target.closest?.(".bd-r2v-play, .bd-r2v-dur, .bd-r2v-progress, .x, video, audio")) return;
                 if (ref && e.target.closest?.(".bd-r2v-thumb")) {
                     slot.querySelector(".bd-r2v-play")?.click();
@@ -1757,6 +1775,23 @@ function appendR2vMediaSections(card, seg, index, editor) {
     );
     const audios = document.createElement("div");
     audios.className = "bd-batch-audios";
+    audios.addEventListener("dragover", (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; });
+    audios.addEventListener("drop", async (e) => {
+        e.preventDefault(); e.stopPropagation();
+        const file = e.dataTransfer.files?.[0];
+        if (file?.type?.startsWith("audio/")) {
+            const seg = editor.timeline.segments[index];
+            const existing = (seg.refAudios || []).filter(r => r && r.audioFile);
+            let next = 0;
+            while (existing.some(r => r && Number(r.index ?? r.slot) === next)) next++;
+            if (next >= 3) { alert("Máx 3 audios"); return; }
+            try {
+                const uploaded = await uploadMedia(file);
+                seg.refAudios = [...existing, { index: next, audioFile: relPath(uploaded), fileName: file.name, type: "input", subfolder: "" }];
+                editor.renderImageBatchGroups(); editor.commit();
+            } catch (err) { console.error("Audio drop failed:", err); }
+        }
+    });
     if (audSlots <= 0 && audOffset > 0) {
         const empty = document.createElement("p");
         empty.className = "bd-r2v-slot-hint";
@@ -1769,6 +1804,7 @@ function appendR2vMediaSections(card, seg, index, editor) {
             const slot = document.createElement("div");
             renderAudioSlot(slot, ref, abs, index, editor, { r2v: true });
             slot.onclick = (e) => {
+                if (e.type === 'drop') { e.preventDefault(); e.stopPropagation(); return; }
                 if (e.target.closest?.(".bd-r2v-play, .bd-r2v-dur, .bd-r2v-progress, .x, video, audio")) return;
                 if (ref && e.target.closest?.(".bd-r2v-thumb")) {
                     slot.querySelector(".bd-r2v-play")?.click();


### PR DESCRIPTION
# 🎬 Fix i2v source display + r2v video/audio drag-and-drop

## Summary

Fixes drag-and-drop issues in **r2v** and **i2v** modes. Users can now properly upload videos and audios via drag-and-drop in r2v mode, and source images will be displayed correctly in i2v mode.

## Problem

- **r2v mode**: Video and audio files could not be added via drag and drop.
- **i2v mode**: Source images could only be uploaded using the **"From library"** button and thumbnails were not displayed.

## Root Cause

- The r2v video and audio containers did not handle drag-and-drop events.
- The i2v source slot did not have drag-and-drop support and was missing DOM rendering for uploaded images.

## Solution

1. **r2v video slots**: Added drag-and-drop handling to the video container.
2. **r2v audio slots**: Added drag-and-drop handling to the audio container.
3. **i2v source slot**: Added drag-and-drop handling to the `.bd-batch-src` element and fixed thumbnail rendering.

## Expected Behavior

### r2v mode

- Drag a video → it is added to the first available video slot.
- Drag an MP3 → it is added to the first available audio slot.
- A maximum of 3 videos and 3 audios can be added per segment.

### i2v mode

- Drag an image → it is uploaded and displayed in the source preview area.
- The thumbnail will be visible immediately after drop.

## Testing Checklist

- [x] i2v: Drop image → thumbnail appears in `.bd-batch-src`
- [x] r2v: Drop video → video appears in video slot
- [x] r2v: Drop audio → audio appears in audio slot
- [x] r2v: Max 3 videos/audios enforced (3 slots total)

---

# 🎬 修复 i2v 源显示 + r2v 视频/音频拖放

## 摘要

修复了 **r2v** 和 **i2v** 模式中的拖放问题。用户现在可以在 r2v 模式下通过拖放正确上传视频和音频，i2v 模式下源图片也会正确显示。

## 问题

- **r2v 模式**：无法通过拖放添加视频和音频文件。
- **i2v 模式**：源图片只能通过 **"From library"** 按钮上传，且缩略图未显示。

## 根本原因

- r2v 视频和音频容器未处理拖放事件。
- i2v 源槽位没有拖放支持，且缺少上传图像的 DOM 渲染。

## 解决方案

1. **r2v 视频槽位**：为视频容器添加拖放处理。
2. **r2v 音频槽位**：为音频容器添加拖放处理。
3. **i2v 源槽位**：为 `.bd-batch-src` 元素添加拖放处理并修复缩略图渲染。

## 预期行为

### r2v 模式

- 拖放视频 → 添加到第一个可用的视频槽位。
- 拖放 MP3 → 添加到第一个可用的音频槽位。
- 每个片段最多可添加 3 个视频和 3 个音频。

### i2v 模式

- 拖放图片 → 上传并在源预览区域显示。
- 拖放后缩略图会立即可见。

## 测试清单

- [x] i2v: 拖放图片 → 缩略图出现在 `.bd-batch-src` 中
- [x] r2v: 拖放视频 → 视频出现在视频槽位
- [x] r2v: 拖放音频 → 音频出现在音频槽位
- [x] r2v: 最多 3 个视频/音频（共 3 个槽位）
