### PR TITLE
Fix continuity compatibility with SolAttn

### DIFF
--- a/director/h3_context_patches.py
+++ b/director/h3_context_patches.py
@@ -312,7 +312,7 @@ def _self_test_layout() -> None:
 
 
 def _classify_layout_owner() -> str | None:
-    """Return None, 'ours', 'foreign_mc', or 'foreign_other'."""
+    """Return None, 'ours', 'compatible_solattn', 'foreign_mc', or 'foreign_other'."""
     mm = _mm()
     init = getattr(getattr(mm, "PackedLayout", None), "__init__", None)
     if init is None:
@@ -321,6 +321,16 @@ def _classify_layout_owner() -> str | None:
         return "ours"
     if getattr(init, "_h3_motion_context_layout_patch", False):
         return "foreign_mc"
+    # SolAttn_triton only observes H3 PackedLayout construction. Its exact
+    # wrapper can safely remain underneath Director's continuity wrapper.
+    # Unknown wrappers are still rejected by the checks below.
+    module = str(getattr(init, "__module__", "")).replace("\\", "/")
+    qualname = getattr(init, "__qualname__", "")
+    if (
+        module.endswith("ComfyUI-SolAttn_triton._morton_h3")
+        and qualname == "_patch_packed_layout.<locals>.__init__"
+    ):
+        return "compatible_solattn"
     if getattr(init, "__name__", "") in {"_patched_init", "_director_layout_init"}:
         return "foreign_other"
     if hasattr(init, "__wrapped__"):
@@ -347,6 +357,8 @@ def ensure_layout_patch() -> bool:
             "already patched MiniMax H3 layout. Disable that custom node pack and "
             "restart ComfyUI — both packs cannot own PackedLayout.__init__."
         )
+    if owner == "compatible_solattn":
+        log.info("Director continuity: composing with SolAttn H3 layout observer")
     if owner == "foreign_other":
         raise RuntimeError(
             "Director continuity: another pack already patched MiniMax H3 "


### PR DESCRIPTION
## Summary

Allow MiniMax H3 Director continuity to work with the exact `PackedLayout.__init__` observer installed by `ComfyUI-SolAttn_triton`.

## Problem

When SolAttn is loaded first, it wraps `PackedLayout.__init__` to record the video-token span. Director classifies this wrapper as `foreign_other`, causing continuity to fail when the second segment starts:

```text
Director continuity: another pack already patched MiniMax H3 PackedLayout.__init__.
Disable the other pack and restart ComfyUI.
```

The first segment completes normally because Director installs its continuity patch only when the next segment begins.

## Why this is safe

SolAttn’s wrapper calls the original constructor and only records information from the completed layout. It does not modify the layout, segment boundaries, or Director continuity state.

This change recognizes only the exact SolAttn wrapper using both:

- Module: `ComfyUI-SolAttn_triton._morton_h3`
- Qualname: `_patch_packed_layout.<locals>.__init__`

Unknown wrappers and the standalone H3 Motion Context patch remain blocked.

## Changes

- Add a `compatible_solattn` owner classification.
- Allow Director continuity to compose with the recognized SolAttn observer.
- Keep rejecting all unknown `PackedLayout.__init__` wrappers.
- Log when the compatible composition is selected.

## Verification

- Python syntax compilation passes.
- Verified that SolAttn calls the original constructor before recording the video span.
- The patched version permits continuity while retaining the existing conflict safeguards.