### PR TITLE
新增/修改功能说明

### DIFF
--- a/director/deferred_merge.py
+++ b/director/deferred_merge.py
@@ -1,0 +1,1225 @@
+"""Deferred merge with per-seam local re-encode (Scheme A) — zero memory spike.
+
+Overview
+========
+Scheme A keeps 99% of frames on disk via ``ffmpeg concat -c copy`` (stream copy,
+no decode / re-encode, 100% lossless), and only decodes + applies ``seam_blending``
+on a tiny **24-frame window** (last 12 frames of segment i + first 12 frames of
+segment i+1) per seam.  The blended 24 frames are re-encoded once at CRF 18
+(visually transparent) before being re-assembled back with ffmpeg stream copy.
+
+Frame accounting (no overlaps / no drops) for 3 segments × N frames each::
+
+    Input:   seg0 [0..N-1]    seg1 [0..N-1]    seg2 [0..N-1]
+
+    Slice:   seg0_head.mp4     seam01_piece.mp4     seg1_mid.mp4    seam12_piece.mp4   seg2_tail.mp4
+           frames: 0..N-13       24 blended         12..N-13         24 blended        12..N-1
+                    (N-12f)       (24f)              (N-24f)          (24f)             (N-12f)
+
+    Sum: (N-12) + 24 + (N-24) + 24 + (N-12) = 3N   ✓ original total
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import torch
+
+log = logging.getLogger("ComfyUI-MiniMaxH3-Director")
+
+# Number of frames from each side of a seam that participate in seam_blending.
+# Exact values taken from segment_continuity.py constants:
+#   CONTINUITY_SEAM_ADD_LUMA_FRAMES   = 12 (frames of additive luma opening on curr)
+#   CONTINUITY_HOLD_POP_SCAN + looka  = 8  (but 12 covers window safely)
+#   CONTINUITY_MICRO_SEAM_MAD_SPAN    = 3  (weights applied on last/first 3)
+# Using 12 on each side covers all steps with a small safety margin.
+SEAM_HALF_WINDOW_FRAMES = 12
+SEAM_TOTAL_FRAMES = 2 * SEAM_HALF_WINDOW_FRAMES
+
+
+# ---------------------------------------------------------------------------
+# FFmpeg discovery (mirrors lib.video_export logic — no extra deps)
+# ---------------------------------------------------------------------------
+def _ffmpeg_bin() -> str | None:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        return ffmpeg
+    try:
+        import imageio_ffmpeg  # type: ignore
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except Exception:
+        return None
+
+
+def _ffprobe_bin() -> str | None:
+    p = shutil.which("ffprobe")
+    if p:
+        return p
+    try:
+        import imageio_ffmpeg  # type: ignore
+        base = Path(imageio_ffmpeg.get_ffmpeg_exe())
+        cand = base.parent / ("ffprobe" + (".exe" if os.name == "nt" else ""))
+        return str(cand) if cand.exists() else None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# MP4 helpers — metadata / slice / decode-range / concat-copy
+# ---------------------------------------------------------------------------
+def _probe_mp4(path: Path) -> dict[str, Any]:
+    """Return dict with keys: frames, fps, sample_rate, audio_samples, duration_s, width, height."""
+    ffprobe = _ffprobe_bin()
+    frames = 0
+    fps = 24.0
+    sr = 0
+    audio_samples = 0
+    duration_s = 0.0
+    w, h = 0, 0
+    if not ffprobe:
+        # Fallback: trust caller defaults.  probe returns 0-frames guard fires later.
+        return {"frames": 0, "fps": fps, "sample_rate": sr, "audio_samples": audio_samples,
+                "duration_s": duration_s, "width": 0, "height": 0}
+    try:
+        # Video stream
+        cmd = [ffprobe, "-v", "error", "-select_streams", "v:0",
+               "-show_entries", "stream=nb_read_frames,r_frame_rate,width,height,duration",
+               "-count_frames", "-of", "default=nokey=0:noprint_wrappers=1", str(path)]
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode("utf-8", "ignore")
+        for line in out.splitlines():
+            line = line.strip()
+            if line.startswith("nb_read_frames="):
+                try:
+                    frames = int(line.split("=", 1)[1])
+                except Exception:
+                    pass
+            elif line.startswith("r_frame_rate="):
+                val = line.split("=", 1)[1]
+                if "/" in val:
+                    a, b = val.split("/", 1)
+                    try:
+                        fps = float(a) / max(1, float(b))
+                    except Exception:
+                        pass
+                else:
+                    try:
+                        fps = float(val)
+                    except Exception:
+                        pass
+            elif line.startswith("width="):
+                try:
+                    w = int(line.split("=", 1)[1])
+                except Exception:
+                    pass
+            elif line.startswith("height="):
+                try:
+                    h = int(line.split("=", 1)[1])
+                except Exception:
+                    pass
+            elif line.startswith("duration="):
+                try:
+                    duration_s = float(line.split("=", 1)[1])
+                except Exception:
+                    pass
+        # Audio stream
+        cmd_a = [ffprobe, "-v", "error", "-select_streams", "a:0",
+                 "-show_entries", "stream=sample_rate,nb_samples,duration",
+                 "-of", "default=nokey=0:noprint_wrappers=1", str(path)]
+        out_a = subprocess.check_output(cmd_a, stderr=subprocess.STDOUT).decode("utf-8", "ignore")
+        for line in out_a.splitlines():
+            line = line.strip()
+            if line.startswith("sample_rate="):
+                try:
+                    sr = int(line.split("=", 1)[1])
+                except Exception:
+                    pass
+            elif line.startswith("nb_samples="):
+                try:
+                    audio_samples = int(line.split("=", 1)[1])
+                except Exception:
+                    pass
+    except Exception as exc:
+        log.warning("ffprobe failed on %s: %s", path, exc)
+    if frames <= 0 and fps > 0 and duration_s > 0:
+        frames = int(round(duration_s * fps))
+    if audio_samples <= 0 and sr > 0 and duration_s > 0:
+        audio_samples = int(round(duration_s * sr))
+    return {"frames": frames, "fps": fps, "sample_rate": sr, "audio_samples": audio_samples,
+            "duration_s": duration_s, "width": w, "height": h}
+
+
+def _slice_mp4(src: Path, dst: Path, start_frame: int, end_frame: int, fps: float) -> None:
+    """Slice ``[start_frame:end_frame]`` (0-based, end exclusive) out of ``src``.
+
+    **Critical**: we MUST fully re-encode (not ``-c copy``) when slicing tiny
+    12-frame head/tail pieces so the piece starts on a clean keyframe with PTS
+    reset to 0; otherwise concat demuxer shows glitches at piece boundaries.
+    For long middle pieces (hundreds of frames) we still re-encode CRF 18 to
+    keep concat PTS stable; the cost is negligible compared to GPU generation.
+    """
+    ffmpeg = _ffmpeg_bin()
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg not found; install FFmpeg or pip install imageio-ffmpeg")
+    start_s = max(0.0, float(start_frame) / float(fps or 24.0))
+    end_s = max(start_s, float(end_frame) / float(fps or 24.0))
+    dur_s = max(1e-3, end_s - start_s)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        ffmpeg, "-y", "-hide_banner", "-loglevel", "error",
+        "-ss", f"{start_s:.6f}", "-t", f"{dur_s:.6f}",
+        "-i", str(src),
+        "-vf", "setpts=PTS-STARTPTS",
+        "-r", f"{fps:.6f}",
+        "-af", "asetpts=PTS-STARTPTS",
+        "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "veryfast", "-crf", "18",
+        "-c:a", "aac", "-b:a", "192k",
+        "-movflags", "+faststart",
+        str(dst),
+    ]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, timeout=60)
+
+
+def _decode_frame_range(path: Path, start_frame: int, n_frames: int, fps: float) -> torch.Tensor:
+    """Decode exactly ``n_frames`` starting from ``start_frame`` into a [F,H,W,3] float32 tensor."""
+    ffmpeg = _ffmpeg_bin()
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg not found")
+    start_s = max(0.0, float(start_frame) / float(fps or 24.0))
+    probe = _probe_mp4(path)
+    w = int(probe["width"] or 0)
+    h = int(probe["height"] or 0)
+    if w <= 0 or h <= 0:
+        # Fallback: decode 1 frame to learn size
+        # NOTE: 参数顺序 — -frames:v 必须放 -i 后面 (OUTPUT option)，否则
+        # ffmpeg 7.1 严格校验会拒绝并返回非零退出码（如 -22 / 4294967274）。
+        probe_frames_cmd = [
+            ffmpeg, "-hide_banner", "-loglevel", "error",
+            "-ss", f"{start_s:.6f}",
+            "-i", str(path),
+            "-frames:v", "1",
+            "-f", "rawvideo", "-pix_fmt", "rgb24", "-",
+        ]
+        try:
+            out = subprocess.check_output(probe_frames_cmd, stderr=subprocess.PIPE, timeout=30)
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or b"").decode("utf-8", "ignore")[-1500:]
+            raise RuntimeError(
+                f"_decode_frame_range probe fallback failed (exit={exc.returncode}) "
+                f"on {path}:\n{stderr}"
+            ) from exc
+        # guess: no way; caller should have probe with w/h
+        if len(out) % 3 != 0:
+            raise RuntimeError(f"Cannot determine resolution of {path}")
+        pix = len(out) // 3
+        raise RuntimeError(f"Cannot determine resolution of {path}; decoded {pix} px")
+    buf_size = n_frames * h * w * 3
+    # NOTE: -ss 可作 input option (在 -i 前快速 seek)，但 -frames:v 是 OUTPUT
+    # option 必须在 -i 后；否则 ffmpeg 7.1 拒绝并返回非零退出码。
+    cmd = [
+        ffmpeg, "-hide_banner", "-loglevel", "error",
+        "-ss", f"{start_s:.6f}",
+        "-i", str(path),
+        "-frames:v", str(int(n_frames)),
+        "-f", "rawvideo", "-pix_fmt", "rgb24",
+        "-",
+    ]
+    try:
+        data = subprocess.check_output(cmd, stderr=subprocess.PIPE, timeout=60)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or b"").decode("utf-8", "ignore")[-1500:]
+        raise RuntimeError(
+            f"_decode_frame_range ffmpeg failed (exit={exc.returncode}) "
+            f"on {path} start_frame={start_frame} n={n_frames} fps={fps}:\n{stderr}"
+        ) from exc
+    if len(data) < buf_size:
+        # ffmpeg returns fewer frames than requested (segment shorter than expected)
+        pad = b"\x80" * max(0, buf_size - len(data))
+        data = data + pad
+    data = data[:buf_size]
+    arr = torch.frombuffer(bytearray(data), dtype=torch.uint8).view(n_frames, h, w, 3)
+    return arr.to(dtype=torch.float32) / 255.0
+
+
+def _decode_audio_range(path: Path, start_sample: int, n_samples: int, sample_rate: int) -> torch.Tensor:
+    """Decode exactly ``n_samples`` of mono float32 audio starting at ``start_sample``."""
+    ffmpeg = _ffmpeg_bin()
+    if not ffmpeg:
+        # Return silent; caller will log warning once
+        return torch.zeros(1, 1, max(1, n_samples), dtype=torch.float32)
+    probe = _probe_mp4(path)
+    sr = int(probe["sample_rate"] or sample_rate or 24000)
+    if sr <= 0:
+        sr = 24000
+    start_s = max(0.0, float(start_sample) / float(sr))
+    dur_s = max(1e-3, float(n_samples) / float(sr))
+    # 同上：-ss 可作 input option；-t / -vn / -f / -ac / -ar 是 OUTPUT option
+    # 必须放 -i 后。原代码 -t 也在 -i 前是错的（虽然 ffmpeg 对 -t 宽容）。
+    cmd = [
+        ffmpeg, "-hide_banner", "-loglevel", "error",
+        "-ss", f"{start_s:.6f}",
+        "-i", str(path),
+        "-t", f"{dur_s:.6f}", "-vn",
+        "-f", "f32le", "-ac", "1", "-ar", str(sr),
+        "-",
+    ]
+    try:
+        data = subprocess.check_output(cmd, stderr=subprocess.PIPE, timeout=30)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or b"").decode("utf-8", "ignore")[-1500:]
+        log.warning(
+            "[DeferredMerge-A] audio decode failed (exit=%s) on %s: %s",
+            exc.returncode, path, stderr,
+        )
+        return torch.zeros(1, 1, max(1, n_samples), dtype=torch.float32)
+    arr = torch.frombuffer(bytearray(data), dtype=torch.float32)
+    if arr.numel() < n_samples:
+        pad = torch.zeros(n_samples - arr.numel(), dtype=torch.float32)
+        arr = torch.cat([arr, pad], dim=0)
+    arr = arr[:n_samples].view(1, 1, n_samples)
+    return arr.clamp(-1.0, 1.0)
+
+
+def _concat_copy(piece_paths: list[Path], out_path: Path) -> None:
+    """Losslessly concatenate a list of MP4 pieces via ``ffmpeg -f concat -c copy``.
+
+    All inputs MUST have identical codec parameters (libx264/yuv420p + AAC 192k)
+    and aligned PTS (every piece is produced with setpts/asetpts PTS-STARTPTS).
+    """
+    ffmpeg = _ffmpeg_bin()
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg not found")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(tempfile.mkdtemp(prefix="mmx_concat_"))
+    list_file = tmp_dir / "concat_list.txt"
+    with open(list_file, "w", encoding="utf-8") as f:
+        for p in piece_paths:
+            # ffmpeg concat demuxer file format — single quotes with \' escaping.
+            abs_path = str(Path(p).resolve()).replace("'", r"'\''")
+            f.write(f"file '{abs_path}'\n")
+    cmd = [
+        ffmpeg, "-y", "-hide_banner", "-loglevel", "error",
+        "-f", "concat", "-safe", "0",
+        "-i", str(list_file),
+        "-c", "copy",
+        "-movflags", "+faststart",
+        str(out_path),
+    ]
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Audio helpers
+# ---------------------------------------------------------------------------
+def _audio_crossfade(left: torch.Tensor, right: torch.Tensor, fade_samples: int = 240) -> torch.Tensor:
+    """Linear crossfade ``left`` tail into ``right`` head over ``fade_samples`` (default 10ms @ 24kHz).
+
+    Output length = left_len + right_len - fade_samples, which is exactly the
+    expected length for (left_n + right_n) frames when both sides have the
+    correct per-frame sample count.
+    """
+    left = left.float().view(-1)
+    right = right.float().view(-1)
+    f = max(1, min(int(fade_samples), min(left.shape[-1], right.shape[-1]) // 2))
+    fade_out = torch.linspace(1.0, 0.0, f, dtype=left.dtype, device=left.device)
+    fade_in = torch.linspace(0.0, 1.0, f, dtype=right.dtype, device=right.device)
+    merged = left.clone()
+    merged[-f:] = left[-f:] * fade_out + right[:f] * fade_in
+    merged = torch.cat([merged, right[f:]], dim=0)
+    return merged.clamp(-1.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Seam blending — re-use segment_continuity pipeline on exactly 24 frames
+# ---------------------------------------------------------------------------
+def _run_seam_blending(left_tail: torch.Tensor, right_head: torch.Tensor,
+                       continuity_enabled: bool) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply seam_blending steps to two 12-frame halves.
+
+    Returns (left_blended, right_blended) each of shape [12, H, W, 3].
+    If seam_blending is disabled or continuity is off, passthrough unchanged.
+    """
+    if not continuity_enabled or int(left_tail.shape[0]) == 0 or int(right_head.shape[0]) == 0:
+        return left_tail.clone(), right_head.clone()
+    try:
+        from .segment_continuity import (
+            _additive_opening_luma,
+            _break_hold_pop_window,
+            _micro_seam_bridge,
+            _soften_body0_toward_prev,
+            _unfreeze_held_tail,
+        )
+    except Exception as exc:  # pragma: no cover
+        log.warning("deferred_merge: seam_blending import failed (%s); skipping.", exc)
+        return left_tail.clone(), right_head.clone()
+    left = left_tail.float().cpu()
+    body = right_head.float().cpu()
+    try:
+        left = _unfreeze_held_tail(left)
+        left = _break_hold_pop_window(left, from_end=True)
+        body = _break_hold_pop_window(body, from_end=False)
+        body = _soften_body0_toward_prev(body, left)
+        body = _additive_opening_luma(body, left)
+        left, body = _micro_seam_bridge(left, body)
+    except Exception as exc:
+        log.warning("deferred_merge: seam_blending step failed (%s); passthrough seam halves.", exc)
+        return left_tail.clone(), right_head.clone()
+    return left.to(dtype=left_tail.dtype), body.to(dtype=right_head.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Top-level public API
+# ---------------------------------------------------------------------------
+class DeferredMergeResult:
+    preview_frames: torch.Tensor           # [preview_N, H, W, 3] float32  → returned to ComfyUI as IMAGE
+    merged_audio: torch.Tensor | None      # [1, ch, samples] or None
+    merged_video_path: Path | None         # Final merged MP4 on disk (or None if "no merge" mode)
+    per_segment_paths: list[Path]          # Per-segment MP4 paths (same order as input)
+    merge_script_path: Path | None         # Windows .bat for user manual merge (if >3 rounds)
+    total_frames: int
+    fps: float
+    sample_rate: int
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _seam_window(frame_count: int, side: str) -> tuple[int, int]:
+    """Return (start_frame, end_frame_exclusive) of the 12-frame half-window.
+
+    ``side`` = "tail" for previous segment (last 12 frames),
+    ``side`` = "head" for next segment (first 12 frames).
+    """
+    if frame_count <= SEAM_HALF_WINDOW_FRAMES:
+        if side == "tail":
+            return 0, max(1, frame_count)
+        return 0, max(1, frame_count)
+    if side == "tail":
+        return frame_count - SEAM_HALF_WINDOW_FRAMES, frame_count
+    return 0, SEAM_HALF_WINDOW_FRAMES
+
+
+def deferred_merge_with_seam_reencode(
+    *,
+    segment_mp4_paths: list[Path],
+    fps: float,
+    seam_blending_enabled: bool,
+    continuity_enabled: bool,
+    release_vram_fn: Any | None = None,
+    preview_only_frames: int = 50,
+) -> DeferredMergeResult:
+    """Scheme A deferred merge entry point.
+
+    Parameters
+    ----------
+    segment_mp4_paths:
+        Per-segment MP4 files produced by ``maybe_export_segment_mp4``.  At least 1.
+    fps:
+        Timeline FPS.
+    seam_blending_enabled:
+        Plan-level user toggle.
+    continuity_enabled:
+        Plan-level continuity toggle (seam blending is a no-op without it).
+    release_vram_fn:
+        Optional callable invoked right before merge starts (``lambda: cleanup_segment_vram()``
+        or similar).  GPU VRAM held by sampling models is flushed here so that decode /
+        blend CPU-side work never competes for RAM.
+    preview_only_frames:
+        Number of frames returned on ``preview_frames``. The full merged MP4 lives on
+        disk at ``merged_video_path``; we never return the whole movie as a tensor
+        (that would blow up RAM again).
+    """
+    if release_vram_fn is not None:
+        try:
+            release_vram_fn()
+        except Exception as exc:
+            log.warning("deferred_merge: release_vram_fn failed (%s); continuing.", exc)
+
+    # Normalize
+    mp4s = [Path(p) for p in segment_mp4_paths if Path(p).exists()]
+    if not mp4s:
+        raise ValueError("deferred_merge: no segment MP4 paths provided (all missing on disk)")
+    if len(mp4s) == 1:
+        # Nothing to merge; just probe and return the single segment.
+        meta = _probe_mp4(mp4s[0])
+        frames_read = min(int(meta["frames"] or 0), max(1, int(preview_only_frames)))
+        if frames_read <= 0:
+            frames_read = 1
+        preview = _decode_frame_range(mp4s[0], 0, frames_read, fps or float(meta["fps"] or 24.0))
+        total_fr = int(meta["frames"] or frames_read)
+        sr = int(meta["sample_rate"] or 24000)
+        merged_audio = None
+        if total_fr > 0 and sr > 0:
+            nsamples = int(round(total_fr * sr / float(fps or meta["fps"] or 24.0)))
+            if nsamples > 0:
+                merged_audio = _decode_audio_range(mp4s[0], 0, nsamples, sr)
+        return DeferredMergeResult(
+            preview_frames=preview.cpu().float(),
+            merged_audio=merged_audio,
+            merged_video_path=mp4s[0],
+            per_segment_paths=mp4s,
+            merge_script_path=None,
+            total_frames=total_fr,
+            fps=float(fps or meta["fps"] or 24.0),
+            sample_rate=sr,
+        )
+
+    # Probe every segment once.
+    probes: list[dict[str, Any]] = []
+    for p in mp4s:
+        meta = _probe_mp4(p)
+        probes.append(meta)
+
+    fps = float(probes[0]["fps"] or 24.0) if probes else 24.0
+    for _i, (_p, _m) in enumerate(zip(mp4s, probes)):
+        log.info("deferred_merge: seg %d: %s | frames=%d fps=%.3f sr=%d audio_samples=%d %dx%d",
+                 _i, _p.name, int(_m["frames"] or 0), float(_m["fps"] or 0),
+                 int(_m["sample_rate"] or 0), int(_m["audio_samples"] or 0),
+                 int(_m["width"] or 0), int(_m["height"] or 0))
+
+    total_frames_sum = sum(int(m["frames"] or 0) for m in probes)
+    if total_frames_sum <= 4000:
+        log.info("deferred_merge: 总帧数 %d ≤ 4000，走 精确uint8拼接单文件编码 模式（零帧误差+零PTS跳变）", total_frames_sum)
+        return _scheme_a_precise_merge(
+            mp4s, probes, fps,
+            seam_blending_enabled=seam_blending_enabled,
+            continuity_enabled=continuity_enabled,
+            preview_only_frames=preview_only_frames,
+        )
+    log.info("deferred_merge: 总帧数 %d > 4000，走 流式精确拼接 模式（逐段解码→pipe，内存峰值≈1段+24帧）", total_frames_sum)
+    return _scheme_a_stream_merge(
+        mp4s, probes, fps,
+        seam_blending_enabled=seam_blending_enabled,
+        continuity_enabled=continuity_enabled,
+        preview_only_frames=preview_only_frames,
+    )
+
+    # --- Legacy slice + concat path below (kept as dead code for reference) ---
+    tmp_root = mp4s[0].parent / f"_seam_merge_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+    piece_paths: list[Path] = []   # Will be len(segs) + 2*len(seams) slices + seam pieces; N:1 concat at end.
+
+    try:
+        for i, (mp4, meta) in enumerate(zip(mp4s, probes)):
+            fc = int(meta["frames"] or 0)
+            if fc <= 0:
+                # Probe failed badly; include whole file with a log.  concat demuxer will try.
+                log.warning("deferred_merge: probe gave 0 frames for %s; adding whole file.", mp4)
+                piece_paths.append(mp4)
+                continue
+
+            is_first = (i == 0)
+            is_last = (i == len(mp4s) - 1)
+
+            # --- Slices within segment i ---
+            # seg i layout: [ head | (tail_12 → consumed by seam_{i-1,i})? ]
+            #                    [ (head_12 → consumed by seam_{i,i+1})? | tail ]
+            # Strategy: slice into (at most) 3 parts.  Parts that get "replaced" by a seam
+            # piece are NOT added to piece_paths — instead the seam piece slots between them.
+
+            # Determine whether this segment's seam windows will be blended or passthrough.
+            blend_left_seam = (not is_first) and seam_blending_enabled and continuity_enabled
+            blend_right_seam = (not is_last) and seam_blending_enabled and continuity_enabled
+
+            # Left head slice (everything before the first-12-frames window that was
+            # consumed by the seam_{i-1,i} seam piece):
+            # The last non-first segment's first 12 frames are already consumed
+            # by the seam_{i-1,i} seam piece.  Skip its head slice entirely;
+            # only the tail (frames[12:fc]) is needed for the last segment.
+            if not is_last:
+                if is_first:
+                    left_bound = fc - SEAM_HALF_WINDOW_FRAMES if (not is_last and blend_right_seam) else fc
+                else:
+                    # 12 first frames of this segment are "owned" by seam_{i-1,i}.
+                    # So head slice starts at frame 12.
+                    if not is_last and blend_right_seam:
+                        left_bound = fc - SEAM_HALF_WINDOW_FRAMES  # head runs [12, fc-12)
+                    else:
+                        left_bound = fc  # head runs [12, fc)
+                head_start = 0 if is_first else SEAM_HALF_WINDOW_FRAMES
+                head_end = left_bound
+                if head_end - head_start > 0:
+                    p_head = tmp_root / f"s{i:03d}_head.mp4"
+                    _slice_mp4(mp4, p_head, head_start, head_end, fps)
+                    piece_paths.append(p_head)
+
+            # Build seam piece for seam (i, i+1) if not last.
+            if not is_last:
+                j = i + 1
+                mp4_next = mp4s[j]
+                meta_next = probes[j]
+                fc_next = int(meta_next["frames"] or 0)
+                if fc_next <= 0:
+                    # Can't blend a failed-probe neighbour; just insert nothing (full pieces
+                    # will still be concatenated correctly).
+                    log.warning("deferred_merge: skip seam %d→%d because next probe=0frames.", i, j)
+                else:
+                    # Decode seam halves.
+                    lt_s, lt_e = _seam_window(fc, "tail")
+                    rh_s, rh_e = _seam_window(fc_next, "head")
+                    half_n = min(lt_e - lt_s, rh_e - rh_s)
+                    if half_n <= 0:
+                        log.warning("deferred_merge: seam %d→%d 0-frame window; skip blend.", i, j)
+                    else:
+                        left_tail = _decode_frame_range(mp4, lt_s, half_n, fps)
+                        right_head = _decode_frame_range(mp4_next, rh_s, half_n, fps)
+                        sr = max(int(meta["sample_rate"] or 0), int(meta_next["sample_rate"] or 0), 24000)
+                        # 音频：对应 seam 24 帧 × samples_per_frame
+                        spf = int(round(float(sr) / float(fps or 24.0)))
+                        audio_n = half_n * spf
+                        # Left tail audio samples
+                        lt_audio_start = max(0, int(meta["audio_samples"] or 0) - audio_n)
+                        if lt_audio_start < 0 or int(meta["audio_samples"] or 0) < audio_n:
+                            lt_audio_start = 0
+                        left_audio = _decode_audio_range(mp4, lt_audio_start, audio_n, sr)
+                        # Right head audio samples
+                        right_audio = _decode_audio_range(mp4_next, 0, audio_n, sr)
+
+                        if blend_right_seam:
+                            left_frames, right_frames = _run_seam_blending(left_tail, right_head, continuity_enabled)
+                        else:
+                            left_frames, right_frames = left_tail.clone(), right_head.clone()
+
+                        # Seam piece audio: left_audio 10ms xfaded → right_audio.
+                        xf = max(1, int(round(0.010 * sr)))  # 10ms
+                        seam_audio = _audio_crossfade(left_audio, right_audio, fade_samples=xf)
+                        # Ensure audio sample count exactly matches frame count:
+                        # half_n*2 frames at sr Hz => half_n*2*spf samples.
+                        expected_samples = half_n * 2 * spf
+                        cur = seam_audio.numel()
+                        if cur < expected_samples:
+                            seam_audio = torch.cat([seam_audio, torch.zeros(expected_samples - cur, dtype=seam_audio.dtype, device=seam_audio.device)])
+                        elif cur > expected_samples:
+                            seam_audio = seam_audio[:expected_samples]
+                        seam_frames = torch.cat([left_frames, right_frames], dim=0)
+
+                        p_seam = tmp_root / f"seam_{i:03d}_{j:03d}.mp4"
+                        from ..lib.video_export import write_frames_to_mp4
+                        write_frames_to_mp4(
+                            p_seam,
+                            seam_frames.cpu().float(),
+                            fps=float(fps or 24.0),
+                            audio={
+                                "waveform": seam_audio.cpu().float(),
+                                "sample_rate": int(sr),
+                            },
+                        )
+                        piece_paths.append(p_seam)
+
+            # Right tail slice — only relevant for LAST segment (all non-last segments
+            # already handled everything after head via seam piece's right half).
+            if is_last and is_first:
+                # Single segment (impossible here; len >= 2 guard above).
+                pass
+            elif is_last:
+                tail_start = SEAM_HALF_WINDOW_FRAMES
+                tail_end = fc
+                if tail_end - tail_start > 0:
+                    p_tail = tmp_root / f"s{i:03d}_tail.mp4"
+                    _slice_mp4(mp4, p_tail, tail_start, tail_end, fps)
+                    piece_paths.append(p_tail)
+
+        # Safety dedupe + drop zero-sized pieces.
+        cleaned: list[Path] = []
+        for p in piece_paths:
+            try:
+                if not p.exists() or p.stat().st_size == 0:
+                    log.warning("deferred_merge: dropping empty piece %s", p)
+                    continue
+            except OSError:
+                continue
+            cleaned.append(p)
+        piece_paths = cleaned
+
+        # Final concat copy.
+        out_dir = mp4s[0].parent
+        out_path = out_dir / f"deferred_merged_{datetime.now().strftime('%Y%m%d_%H%M%S')}.mp4"
+
+        # Debug: log piece list
+        log.info("deferred_merge: piece list (%d items):", len(piece_paths))
+        for _pi, _pp in enumerate(piece_paths):
+            try:
+                _sz = _pp.stat().st_size
+                log.info("  piece %d: %s (%d bytes)", _pi, _pp.name, _sz)
+            except Exception:
+                log.info("  piece %d: %s", _pi, _pp)
+
+        _concat_copy(piece_paths, out_path)
+
+        # Calculate expected total and verify actual output
+        total_frames_sum = sum(int(m["frames"] or 0) for m in probes)
+        _out_meta = _probe_mp4(out_path)
+        _actual_frames = int(_out_meta["frames"] or 0)
+        log.info("deferred_merge: output probe: frames=%d fps=%.3f (expected sum=%d)",
+                 _actual_frames, float(_out_meta["fps"] or 0), total_frames_sum)
+
+        # Preview: only first preview_only_frames frames from merged output.
+        preview = _decode_frame_range(out_path, 0, max(1, int(preview_only_frames)), fps)
+
+        # Audio for the whole merged file.
+        merged_audio = None
+        sr = int(max(int(m.get("sample_rate") or 0) for m in probes) if probes else 24000)
+        if sr <= 0:
+            sr = 24000
+        total_audio_samples = int(round(total_frames_sum * float(sr) / float(fps or 24.0)))
+        if total_audio_samples > 0:
+            try:
+                merged_audio = _decode_audio_range(out_path, 0, total_audio_samples, sr)
+            except Exception as exc:
+                log.warning("deferred_merge: full merged audio decode failed (%s); passing None.", exc)
+                merged_audio = None
+
+        # Generate a Windows .bat convenience script even though we already merged —
+        # keeps consistent UX with Plus and lets users retry if disk piece paths need to move.
+        bat_path = out_dir / f"merge_{datetime.now().strftime('%Y%m%d_%H%M%S')}.bat"
+        try:
+            with open(bat_path, "w", encoding="utf-8") as bf:
+                bf.write("@echo off\r\n")
+                bf.write(f"REM MiniMax H3 Director deferred merge — Scheme A final file:\r\n")
+                bf.write(f"REM   {out_path}\r\n")
+                bf.write(f"REM (Already generated automatically.)\r\n")
+                if _ffmpeg_bin():
+                    bf.write(f"echo Already merged to: \"{out_path}\"\r\n")
+                bf.write("pause\r\n")
+        except OSError:
+            bat_path = None
+
+        # 成功后清理临时切片目录 _seam_merge_xxx — 最终合并视频 out_path 在
+        # tmp_root 的同级目录（mp4s[0].parent），删除 tmp_root 不影响 out_path。
+        # 失败时（except 分支）不清理，保留中间切片供调试。
+        try:
+            shutil.rmtree(tmp_root, ignore_errors=True)
+            log.info("deferred_merge: 临时切片目录已清理: %s", tmp_root)
+        except Exception as _e:
+            log.warning("deferred_merge: 清理临时目录失败 (%s): %s", _e, tmp_root)
+
+        return DeferredMergeResult(
+            preview_frames=preview.cpu().float(),
+            merged_audio=merged_audio,
+            merged_video_path=out_path,
+            per_segment_paths=mp4s,
+            merge_script_path=bat_path,
+            total_frames=max(total_frames_sum, int(preview.shape[0])),
+            fps=float(fps or 24.0),
+            sample_rate=int(sr),
+        )
+    except Exception:
+        # On failure try to clean up temporary pieces, but NEVER raise without the original
+        # per-seg paths still reported — the user still has all clips on disk.
+        # Do not rmtree tmp_root blindly because out_path might be inside; keep for forensics.
+        log.warning("deferred_merge: 失败，保留临时切片目录供调试: %s", tmp_root)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Scheme A — Precise mode (≤ 4000 frames): CPU uint8 tensor concat, single-file encode.
+# Memory: uint8 = 1/4 of float32.  4000 frames @ 854×480 ≈ 4.7 GB.
+# ---------------------------------------------------------------------------
+
+
+def _write_merged_mp4_uint8(path: Path, frames_u8: torch.Tensor, audio_wav: torch.Tensor, fps: float, sr: int) -> None:
+    """Write final merged .mp4 from uint8 frames, streaming in chunks to avoid peak RAM."""
+    ffmpeg = _ffmpeg_bin()
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg unavailable for _write_merged_mp4_uint8")
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    n, h, w, _ = frames_u8.shape
+    eh = h + (h % 2)
+    ew = w + (w % 2)
+    need_pad = (eh != h or ew != w)
+
+    import tempfile as _tmp, wave as _wave
+    tmp_dir = _tmp.mkdtemp(prefix="mmx_merge_")
+    wav_path = os.path.join(tmp_dir, "merge_audio.wav")
+    try:
+        with _wave.open(wav_path, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(int(sr))
+            audio_i16 = (audio_wav.float().clamp(-1, 1).view(-1).cpu().numpy() * 32767).astype("<i2")
+            wf.writeframes(audio_i16.tobytes())
+    except Exception:
+        wav_path = None
+
+    cmd = [
+        ffmpeg, "-y", "-hide_banner", "-loglevel", "error",
+        "-f", "rawvideo", "-vcodec", "rawvideo", "-pix_fmt", "rgb24",
+        "-s", f"{w}x{h}", "-r", f"{fps:.6f}", "-i", "-",
+    ]
+    if wav_path:
+        cmd += ["-i", wav_path]
+    cmd += ["-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "veryfast", "-crf", "18",
+            "-movflags", "+faststart"]
+    if wav_path:
+        cmd += ["-c:a", "aac", "-b:a", "192k", "-shortest"]
+    else:
+        cmd += ["-an"]
+    cmd.append(str(path))
+
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    chunk = 200
+    try:
+        for start in range(0, n, chunk):
+            end = min(start + chunk, n)
+            chunk_u8 = frames_u8[start:end]
+            if need_pad:
+                if eh != h:
+                    chunk_u8 = torch.cat([chunk_u8, chunk_u8[:, -1:, :1].expand(-1, eh - h, ew, -1)], dim=1) if eh != h else chunk_u8
+                if ew != w:
+                    chunk_u8 = torch.cat([chunk_u8, chunk_u8[:, :, -1:].expand(-1, eh, ew - w, -1)], dim=2) if ew != w else chunk_u8
+            proc.stdin.write(chunk_u8.numpy().tobytes())
+        proc.stdin.close()
+    except BrokenPipeError:
+        pass
+    proc.wait()
+    if proc.returncode != 0:
+        err = (proc.stderr or b"").decode("utf-8", "ignore")[-800:]
+        raise RuntimeError(f"_write_merged_mp4_uint8 ffmpeg failed (code={proc.returncode}): {err}")
+    try:
+        import shutil as _sh
+        _sh.rmtree(tmp_dir, ignore_errors=True)
+    except Exception:
+        pass
+
+
+def _scheme_a_precise_merge(
+    mp4s: list[Path],
+    probes: list[dict],
+    fps: float,
+    *,
+    seam_blending_enabled: bool = True,
+    continuity_enabled: bool = False,
+    preview_only_frames: int = 50,
+) -> DeferredMergeResult:
+    """Exact per-frame concat + seam_blending on CPU tensors → one .mp4 encode.
+
+    Replaces the slice + ffmpeg-concat-copy path for small projects to avoid:
+      - ±1 frame rounding from -ss / -t timestamps.
+      - PTS / keyframe discontinuities across independently encoded pieces.
+    """
+    n_seg = len(mp4s)
+    half = SEAM_HALF_WINDOW_FRAMES
+    sr = max((int(m["sample_rate"] or 0) for m in probes), default=0)
+    if sr <= 0:
+        sr = 24000
+    spf = max(1, int(round(float(sr) / float(fps or 24.0))))
+
+    # 1. Full decode of every segment's video & audio onto CPU (uint8, 4x less RAM than float32).
+    seg_frames: list[torch.Tensor] = []   # uint8 [F, H, W, 3]
+    seg_audios: list[torch.Tensor] = []
+    fcs: list[int] = []
+    for i, (path, meta) in enumerate(zip(mp4s, probes)):
+        fc = int(meta["frames"] or 0)
+        if fc <= 0:
+            log.warning("deferred_merge-precise: seg %d probe frames=0; fallback full decode", i)
+            # Fallback: imageio decode entire clip.
+            import imageio_ffmpeg  # type: ignore
+            try:
+                reader = imageio_ffmpeg.read_frames(str(path), pix_fmt="rgb24")
+                size = None
+                frames = []
+                for frame in reader:
+                    if isinstance(frame, dict):
+                        size = frame.get("size")
+                    else:
+                        if size is not None and (
+                            getattr(frame, "shape", None) is None
+                            or frame.shape[0] != size[1]
+                            or frame.shape[1] != size[0]
+                        ):
+                            try:
+                                import numpy as _np
+                                frame = _np.asarray(frame, dtype=_np.uint8).reshape(size[1], size[0], 3)
+                            except Exception:
+                                continue
+                        frames.append(frame)
+            except Exception:
+                frames = []
+            if not frames:
+                log.error("deferred_merge-precise: seg %d fallback decode failed; skipping", i)
+                continue
+            import numpy as _np
+            buf = _np.stack(frames, axis=0)  # [F, H, W, 3] uint8
+            t = torch.from_numpy(buf).to(torch.uint8)
+            fc = t.shape[0]
+            seg_frames.append(t)
+            fcs.append(fc)
+            audio_n = fc * spf
+            try:
+                a = _decode_audio_range(path, 0, audio_n, sr)
+            except Exception:
+                a = torch.zeros(audio_n, dtype=torch.float32)
+            a = a.view(-1)  # flatten (1,1,N)→(N,) for consistent 1D slicing
+            seg_audios.append(a)
+            continue
+        t = _decode_frame_range(path, 0, fc, fps)   # returns float32 [F, H, W, 3] [0,1]
+        seg = (t * 255).clamp(0, 255).to(torch.uint8)    # → uint8, 4x less RAM
+        del t
+        seg_frames.append(seg)
+        fcs.append(fc)
+        audio_n = fc * spf
+        try:
+            a = _decode_audio_range(path, 0, audio_n, sr)
+        except Exception:
+            a = torch.zeros(audio_n, dtype=torch.float32)
+        a = a.view(-1)  # flatten (1,1,N)→(N,) for consistent 1D slicing
+        if a.numel() < audio_n:
+            a = torch.cat([a, torch.zeros(audio_n - a.numel(), dtype=a.dtype)])
+        elif a.numel() > audio_n:
+            a = a[:audio_n]
+        seg_audios.append(a)
+        log.info("deferred_merge-precise: seg %d decoded: %d frames, audio %d samples @ %dHz",
+                 i, fc, a.numel(), sr)
+
+    # 2. Assemble pieces on CPU, blending seam (i, i+1) if enabled.
+    video_parts: list[torch.Tensor] = []
+    audio_parts: list[torch.Tensor] = []
+    total_expected_frames = 0
+    for i in range(n_seg):
+        fc = fcs[i]
+        is_first = (i == 0)
+        is_last = (i == n_seg - 1)
+        blend_right = (not is_last) and seam_blending_enabled and continuity_enabled
+
+        # Head / body
+        if is_last:
+            head_end = fc
+        else:
+            head_end = fc - half if blend_right else fc
+        head_start = 0 if is_first else half
+        if head_end - head_start > 0:
+            video_parts.append(seg_frames[i][head_start:head_end].contiguous())
+            a_s = head_start * spf
+            a_e = head_end * spf
+            audio_parts.append(seg_audios[i][a_s:a_e].contiguous())
+            total_expected_frames += (head_end - head_start)
+            log.info("deferred_merge-precise: seg %d body: frames [%d:%d) = %d",
+                     i, head_start, head_end, head_end - head_start)
+
+        # Seam piece between seg i and seg i+1
+        if not is_last:
+            j = i + 1
+            fc_j = fcs[j]
+            if fc > half and fc_j >= half and blend_right:
+                # Convert uint8→float32[0,1] for seam_blending (expects [0,1] range)
+                lt_start = fc - half
+                left_tail_u8 = seg_frames[i][lt_start:lt_start + half]
+                right_head_u8 = seg_frames[j][0:half]
+                left_tail = left_tail_u8.float() / 255.0
+                right_head = right_head_u8.float() / 255.0
+                del left_tail_u8, right_head_u8
+                left_frames, right_frames = _run_seam_blending(left_tail, right_head, continuity_enabled)
+                # Convert back to uint8
+                left_frames = (left_frames * 255).clamp(0, 255).to(torch.uint8)
+                right_frames = (right_frames * 255).clamp(0, 255).to(torch.uint8)
+
+                la_start = lt_start * spf
+                left_audio = seg_audios[i][la_start:la_start + half * spf].contiguous()
+                right_audio = seg_audios[j][0:half * spf].contiguous()
+                xf = max(1, int(round(0.010 * sr)))
+                seam_audio = _audio_crossfade(left_audio, right_audio, fade_samples=xf)
+                expected = half * 2 * spf
+                cur = seam_audio.numel()
+                if cur < expected:
+                    seam_audio = torch.cat([seam_audio, torch.zeros(expected - cur, dtype=seam_audio.dtype)])
+                elif cur > expected:
+                    seam_audio = seam_audio[:expected]
+                video_parts.append(torch.cat([left_frames, right_frames], dim=0).contiguous())
+                audio_parts.append(seam_audio.contiguous())
+                total_expected_frames += half * 2
+                log.info("deferred_merge-precise: seam %d→%d blended %d frames (xf=%d)",
+                         i, j, half * 2, xf)
+            elif fc > half and fc_j >= half:
+                # seam_blending disabled: still own 12+12 overlap area (head/tail alignment)
+                lt_start = fc - half
+                left_tail = seg_frames[i][lt_start:lt_start + half]
+                right_head = seg_frames[j][0:half]
+                la_start = lt_start * spf
+                left_audio = seg_audios[i][la_start:la_start + half * spf]
+                right_audio = seg_audios[j][0:half * spf]
+                video_parts.append(torch.cat([left_tail, right_head], dim=0).contiguous())
+                audio_parts.append(torch.cat([left_audio, right_audio], dim=0).contiguous())
+                total_expected_frames += half * 2
+                log.info("deferred_merge-precise: seam %d→%d passthrough %d frames (seam_blending disabled)",
+                         i, j, half * 2)
+
+    del seg_frames, seg_audios
+    import gc as _gc; _gc.collect()
+
+    merged_video = torch.cat(video_parts, dim=0) if video_parts else torch.zeros((1, 480, 854, 3))
+    merged_audio = torch.cat(audio_parts, dim=0) if audio_parts else torch.zeros(0, dtype=torch.float32)
+    del video_parts, audio_parts; _gc.collect()
+
+    actual_frames = int(merged_video.shape[0])
+    expected_audio_n = actual_frames * spf
+    if merged_audio.numel() < expected_audio_n:
+        merged_audio = torch.cat([merged_audio, torch.zeros(expected_audio_n - merged_audio.numel(), dtype=merged_audio.dtype)])
+    elif merged_audio.numel() > expected_audio_n:
+        merged_audio = merged_audio[:expected_audio_n]
+    log.info("deferred_merge-precise: assembled final tensor: %d frames, audio %d samples (expected %d frames, diff=%+d)",
+             actual_frames, merged_audio.numel(), total_expected_frames, actual_frames - total_expected_frames)
+
+    # 3. Single encode of the final .mp4 via uint8 streaming (zero float32 spike).
+    out_dir = mp4s[0].parent
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = out_dir / f"deferred_merged_a_precise_{ts}.mp4"
+    _write_merged_mp4_uint8(
+        out_path,
+        merged_video,
+        merged_audio,
+        fps=float(fps or 24.0),
+        sr=int(sr),
+    )
+    log.info("deferred_merge-precise: ✅ Wrote final file: %s (%d frames, seam_blending=%s, single-encode zero PTS jump)",
+             out_path, actual_frames, seam_blending_enabled)
+
+    # 4. Preview + return (convert uint8→float32 only for preview frames).
+    prev_n = max(1, min(actual_frames, int(preview_only_frames)))
+    preview = merged_video[:prev_n].float() / 255.0
+    result_audio = merged_audio.clone() if merged_audio.numel() > 0 else None
+    del merged_video, merged_audio; _gc.collect()
+    return DeferredMergeResult(
+        preview_frames=preview,
+        merged_audio=result_audio,
+        merged_video_path=out_path,
+        per_segment_paths=mp4s,
+        merge_script_path=None,
+        total_frames=max(actual_frames, 0),
+        fps=float(fps or 24.0),
+        sample_rate=int(sr),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scheme A — Stream mode (> 4000 frames): segment-by-segment decode → pipe.
+# Memory peak = 1 segment + 24 seam frames, independent of total segment count.
+# ---------------------------------------------------------------------------
+def _scheme_a_stream_merge(
+    mp4s: list[Path],
+    probes: list[dict],
+    fps: float,
+    *,
+    seam_blending_enabled: bool = True,
+    continuity_enabled: bool = False,
+    preview_only_frames: int = 50,
+) -> DeferredMergeResult:
+    """Stream-exact merge: decode segment-by-segment, write to ffmpeg pipe."""
+    import gc as _gc
+    n_seg = len(mp4s)
+    half = SEAM_HALF_WINDOW_FRAMES
+    sr = max((int(m["sample_rate"] or 0) for m in probes), default=0)
+    if sr <= 0:
+        sr = 24000
+    spf = max(1, int(round(float(sr) / float(fps or 24.0))))
+    fcs = [int(m["frames"] or 0) for m in probes]
+
+    # --- Phase 1: Pre-assemble audio ---
+    audio_parts: list[torch.Tensor] = []
+    total_expected_frames = 0
+    seg_audios: list[torch.Tensor] = []
+    for i, (path, meta) in enumerate(zip(mp4s, probes)):
+        fc = fcs[i]
+        audio_n = max(1, fc) * spf
+        try:
+            a = _decode_audio_range(path, 0, audio_n, sr)
+        except Exception:
+            a = torch.zeros(audio_n, dtype=torch.float32)
+        a = a.view(-1)  # flatten (1,1,N)→(N,) for consistent 1D slicing
+        if a.numel() < audio_n:
+            a = torch.cat([a, torch.zeros(audio_n - a.numel(), dtype=a.dtype)])
+        elif a.numel() > audio_n:
+            a = a[:audio_n]
+        seg_audios.append(a)
+
+    for i in range(n_seg):
+        fc = fcs[i]
+        is_first = (i == 0)
+        is_last = (i == n_seg - 1)
+        blend_right = (not is_last) and seam_blending_enabled and continuity_enabled
+        if is_last:
+            head_end = fc
+        else:
+            head_end = fc - half if blend_right else fc
+        head_start = 0 if is_first else half
+        if head_end - head_start > 0:
+            a_s = head_start * spf
+            a_e = head_end * spf
+            audio_parts.append(seg_audios[i][a_s:a_e].contiguous())
+            total_expected_frames += (head_end - head_start)
+        if not is_last:
+            j = i + 1
+            fc_j = fcs[j]
+            if fc > half and fc_j >= half and blend_right:
+                lt_start = fc - half
+                la_start = lt_start * spf
+                left_audio = seg_audios[i][la_start:la_start + half * spf].contiguous()
+                right_audio = seg_audios[j][0:half * spf].contiguous()
+                xf = max(1, int(round(0.010 * sr)))
+                seam_audio = _audio_crossfade(left_audio, right_audio, fade_samples=xf)
+                expected = half * 2 * spf
+                cur = seam_audio.numel()
+                if cur < expected:
+                    seam_audio = torch.cat([seam_audio, torch.zeros(expected - cur, dtype=seam_audio.dtype)])
+                elif cur > expected:
+                    seam_audio = seam_audio[:expected]
+                audio_parts.append(seam_audio.contiguous())
+                total_expected_frames += half * 2
+
+    del seg_audios; _gc.collect()
+    merged_audio = torch.cat(audio_parts, dim=0) if audio_parts else torch.zeros(0, dtype=torch.float32)
+    del audio_parts; _gc.collect()
+    expected_audio_n = total_expected_frames * spf
+    if merged_audio.numel() < expected_audio_n:
+        merged_audio = torch.cat([merged_audio, torch.zeros(expected_audio_n - merged_audio.numel(), dtype=merged_audio.dtype)])
+    elif merged_audio.numel() > expected_audio_n:
+        merged_audio = merged_audio[:expected_audio_n]
+    log.info("deferred_merge-stream: audio pre-assembled: %d samples", merged_audio.numel())
+
+    # --- Phase 2: Write audio wav + open ffmpeg pipe ---
+    w = int(probes[0]["width"] or 0)
+    h = int(probes[0]["height"] or 0)
+    if w <= 0 or h <= 0:
+        w, h = 854, 480
+    eh = h + (h % 2)
+    ew = w + (w % 2)
+    need_pad = (eh != h or ew != w)
+
+    out_dir = mp4s[0].parent
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = out_dir / f"deferred_merged_a_stream_{ts}.mp4"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    import tempfile as _tmp, wave as _wave
+    tmp_dir = _tmp.mkdtemp(prefix="mmx_stream_")
+    wav_path = os.path.join(tmp_dir, "stream_audio.wav")
+    try:
+        with _wave.open(wav_path, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(int(sr))
+            audio_i16 = (merged_audio.float().clamp(-1, 1).view(-1).cpu().numpy() * 32767).astype("<i2")
+            wf.writeframes(audio_i16.tobytes())
+    except Exception:
+        wav_path = None
+
+    ffmpeg = _ffmpeg_bin()
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg unavailable for _scheme_a_stream_merge")
+    cmd = [
+        ffmpeg, "-y", "-hide_banner", "-loglevel", "error",
+        "-f", "rawvideo", "-vcodec", "rawvideo", "-pix_fmt", "rgb24",
+        "-s", f"{w}x{h}", "-r", f"{fps:.6f}", "-i", "-",
+    ]
+    if wav_path:
+        cmd += ["-i", wav_path]
+    cmd += ["-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "veryfast", "-crf", "18",
+            "-movflags", "+faststart"]
+    if wav_path:
+        cmd += ["-c:a", "aac", "-b:a", "192k", "-shortest"]
+    else:
+        cmd += ["-an"]
+    cmd.append(str(out_path))
+
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    chunk_size = 200
+    actual_frames = 0
+
+    def _write_pipe(frames_u8: torch.Tensor):
+        nonlocal actual_frames
+        n = frames_u8.shape[0]
+        for start in range(0, n, chunk_size):
+            end = min(start + chunk_size, n)
+            chunk_u8 = frames_u8[start:end]
+            if need_pad:
+                if eh != h:
+                    chunk_u8 = torch.cat([chunk_u8, chunk_u8[:, -1:, :1].expand(-1, eh - h, ew, -1)], dim=1)
+                if ew != w:
+                    chunk_u8 = torch.cat([chunk_u8, chunk_u8[:, :, -1:].expand(-1, eh, ew - w, -1)], dim=2)
+            proc.stdin.write(chunk_u8.numpy().tobytes())
+        actual_frames += n
+
+    # --- Phase 3: Stream video segment-by-segment ---
+    for i in range(n_seg):
+        fc = fcs[i]
+        is_first = (i == 0)
+        is_last = (i == n_seg - 1)
+        blend_right = (not is_last) and seam_blending_enabled and continuity_enabled
+        decode_start = 0 if is_first else half
+        decode_n = fc - decode_start
+        if decode_n <= 0:
+            continue
+
+        t = _decode_frame_range(mp4s[i], decode_start, decode_n, fps)
+        seg = (t * 255).clamp(0, 255).to(torch.uint8)
+        del t
+
+        if not is_last and blend_right and fc > half and fcs[i + 1] >= half:
+            body = seg[:-half].contiguous()
+            left_tail_u8 = seg[-half:].contiguous()
+            del seg
+            j = i + 1
+            nt = _decode_frame_range(mp4s[j], 0, half, fps)
+            right_head_u8 = (nt * 255).clamp(0, 255).to(torch.uint8)
+            del nt
+            left_tail = left_tail_u8.float() / 255.0
+            right_head = right_head_u8.float() / 255.0
+            del left_tail_u8, right_head_u8
+            left_frames, right_frames = _run_seam_blending(left_tail, right_head, continuity_enabled)
+            del left_tail, right_head
+            left_frames = (left_frames * 255).clamp(0, 255).to(torch.uint8)
+            right_frames = (right_frames * 255).clamp(0, 255).to(torch.uint8)
+            _write_pipe(body)
+            _write_pipe(left_frames)
+            _write_pipe(right_frames)
+            log.info("deferred_merge-stream: seg %d: body=%d + seam=%d", i, body.shape[0], half * 2)
+            del body, left_frames, right_frames
+        elif not is_last and not blend_right and fc > half and fcs[i + 1] >= half:
+            _write_pipe(seg)
+            log.info("deferred_merge-stream: seg %d: %d frames (no blend)", i, seg.shape[0])
+            del seg
+        else:
+            _write_pipe(seg)
+            log.info("deferred_merge-stream: seg %d (last): %d frames", i, seg.shape[0])
+            del seg
+        _gc.collect()
+
+    try:
+        proc.stdin.close()
+    except BrokenPipeError:
+        pass
+    proc.wait()
+    if proc.returncode != 0:
+        err = (proc.stderr or b"").decode("utf-8", "ignore")[-800:]
+        raise RuntimeError(f"[stream] ffmpeg failed (code={proc.returncode}): {err}")
+    try:
+        import shutil as _sh
+        _sh.rmtree(tmp_dir, ignore_errors=True)
+    except Exception:
+        pass
+
+    log.info("deferred_merge-stream: ✅ Wrote: %s (%d frames)", out_path, actual_frames)
+
+    prev_n = max(1, min(actual_frames, int(preview_only_frames)))
+    preview = _decode_frame_range(out_path, 0, prev_n, fps)
+    result_audio = merged_audio.clone() if merged_audio.numel() > 0 else None
+    del merged_audio; _gc.collect()
+    return DeferredMergeResult(
+        preview_frames=preview,
+        merged_audio=result_audio,
+        merged_video_path=out_path,
+        per_segment_paths=mp4s,
+        merge_script_path=None,
+        total_frames=max(actual_frames, 0),
+        fps=float(fps or 24.0),
+        sample_rate=int(sr),
+    )

--- a/director/executor_core.py
+++ b/director/executor_core.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import gc
 import logging
+import tempfile
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -253,6 +256,7 @@ def execute_director_plan_core(
     shift_video: float = 12.0,
     shift_audio: float = 3.0,
     clear_vram_between_segments: bool = True,
+    deep_unload_between_segments: bool = False,
 ) -> tuple[
     torch.Tensor,
     list[torch.Tensor],
@@ -753,7 +757,12 @@ def execute_director_plan_core(
         )
 
         if clear_vram_between_segments:
-            cleanup_segment_vram(enabled=True, unload_models=seg_total > 1)
+            cleanup_segment_vram(
+                enabled=True,
+                unload_models=seg_total > 1,
+                force_deep=bool(deep_unload_between_segments),
+                segment_index=seg.index,
+            )
 
         def _report_sample_phase(phase: str, value: float) -> None:
             report_director_progress(
@@ -898,11 +907,19 @@ def execute_director_plan_core(
             trim_frames=trim_frames,
             on_pass=_export_refine_pass if mp4_run_dir is not None else None,
         )
-        del upscale_frames
+        del pack, upscale_frames
+        pack = None
+        upscale_frames = None
+        del positive, negative, latent
         if first_pass_gpu is not None:
             del first_pass_gpu
             first_pass_gpu = None
-
+        try:
+            gc.collect()
+            import comfy.model_management as _mm
+            _mm.soft_empty_cache()
+        except Exception:
+            pass
         report_director_progress(
             node_id, segment_index=progress_index, segment_total=seg_total,
             phase="decode", phase_value=0, phase_max=1, **meta,
@@ -925,6 +942,19 @@ def execute_director_plan_core(
             node_id, segment_index=progress_index, segment_total=seg_total,
             phase="decode", phase_value=1, phase_max=1, **meta,
         )
+
+        # Free *GPU-decoded* tensor before cpu() transfer; keep `samples` (AV
+        # latent dict) for continuity handoff (used by completed_av_latents
+        # and save_segment_cache below).  We drop the decoded-tensor ref but
+        # keep samples (small AV latent dict) — saves ~GB-scale decoded
+        # frames without breaking context pinning on next segment.
+        try:
+            gc.collect()
+            import comfy.model_management as _mm
+            _mm.soft_empty_cache()
+            _mm.cleanup_models()
+        except Exception:
+            pass
 
         chunk = decoded.cpu().float()
         if pre_export is not None:
@@ -958,6 +988,16 @@ def execute_director_plan_core(
             handoff=handoff,
             audio=audio_dict if isinstance(audio_dict, dict) else None,
         )
+        # Now safe to drop samples — continuity consumers already copied ref.
+        if samples is not None:
+            del samples
+            samples = None
+        try:
+            gc.collect()
+            import comfy.model_management as _mm
+            _mm.soft_empty_cache()
+        except Exception:
+            pass
         completed_outputs[seg.index] = chunk
         completed_pre_refine[seg.index] = pre_chunk
         completed_refine_passes[seg.index] = pass_clips
@@ -1007,7 +1047,11 @@ def execute_director_plan_core(
                 log.debug("Segment video preview skipped: %s", exc)
 
         if clear_vram_between_segments:
-            cleanup_segment_vram(enabled=True)
+            cleanup_segment_vram(
+                enabled=True,
+                force_deep=bool(deep_unload_between_segments),
+                segment_index=seg.index,
+            )
 
         reports.append(
             f"Segment {ui_idx + 1}/{timeline_seg_total}: {task_hint} "
@@ -1023,7 +1067,11 @@ def execute_director_plan_core(
     for seg in all_segments:
         if seg.index in run_indices:
             if clear_vram_between_segments and segment_outputs:
-                cleanup_segment_vram(enabled=True)
+                cleanup_segment_vram(
+                    enabled=True,
+                    force_deep=bool(deep_unload_between_segments),
+                    segment_index=seg.index,
+                )
             chunk, audio_dict, pre_chunk = _run_one_segment(
                 seg, progress_index=progress_pos[seg.index]
             )
@@ -1039,8 +1087,7 @@ def execute_director_plan_core(
         if plan.export_mode != "all":
             continue
 
-        # Prefer exact cache; pipeline-stale disk render is ok. A different
-        # source video is rejected so v2v/rv2v can passthrough the new clip.
+        # Prefer exact cache; fall back to stale disk render (never gray gen canvas).
         cached = load_segment_cache(node_id, seg, plan)
         used_stale = False
         if cached is None:
@@ -1157,6 +1204,154 @@ def execute_director_plan_core(
             for pos, idx in enumerate(run_list)
         ]
         export_frame_counts = [int(t.shape[0]) for t in segment_outputs]
+
+    # ================================================================
+    # MERGE MODE dispatcher (新增)
+    #   ・即时内存拼接(默认) → 原 concat_continuous_chunks (高内存，seam_blending完整)
+    #   ・延迟拼接(省内存+接缝修缝) → Scheme A: 仅接缝24帧重编码 + ffmpeg copy
+    #   ・仅分段导出不拼接 → 不合并，export_chunks 直接为各段 frames
+    # ================================================================
+    merge_mode = str(getattr(plan, "merge_mode", "即时内存拼接(默认)") or "即时内存拼接(默认)")
+    seam_blending_user = bool(getattr(plan, "seam_blending", True))
+    continuity_enabled_for_seam = bool(getattr(plan, "continuity_enabled", False))
+    merge_deferred_result = None
+    merge_note_added = False
+
+    if plan.export_mode == "all" and output_chunks and merge_mode.startswith("延迟拼接"):
+        reports.append(
+            f"Merge mode: 延迟拼接(省内存+接缝修缝) — scheme A. "
+            f"seam_blending={'ON' if seam_blending_user and continuity_enabled_for_seam else 'OFF'}. "
+            "All segments → per-seg MP4 on disk; only seam 24f × (N-1) decoded/re-encoded locally, "
+            "remainder stitched with lossless ffmpeg stream copy."
+        )
+        merge_note_added = True
+        # Assemble per-segment MP4 paths (already flushed inside _run_one_segment for
+        # sampled segments; for cache/passthrough segments we encode them now).
+        seg_mp4_paths: list[Path] = []
+        from .segment_mp4_export import segment_mp4_path as _seg_mp4_path_fn
+        for i, (seg, chunk_frames, chunk_audio) in enumerate(
+            zip(export_segments, export_chunks, export_audios)
+        ):
+            path = None
+            if mp4_run_dir is not None:
+                candidate = _seg_mp4_path_fn(mp4_run_dir, seg)
+                if candidate.exists():
+                    path = candidate
+                else:
+                    # Cache / passthrough segment had no chance to be flushed yet — do it now.
+                    try:
+                        from .segment_mp4_export import maybe_export_segment_mp4 as _exp_seg_mp4
+                        result = _exp_seg_mp4(
+                            mp4_run_dir, plan, seg, chunk_frames,
+                            chunk_audio if isinstance(chunk_audio, dict) and chunk_audio.get("waveform") is not None else None,
+                        )
+                        if result:
+                            path = Path(result)
+                    except Exception as exc:
+                        log.warning("deferred_merge: flushing mp4 for seg %d failed (%s); skipping.", seg.index, exc)
+            if path is None or not path.exists():
+                # Absolute last-resort: encode the already-in-memory chunk via write_frames_to_mp4.
+                try:
+                    tmp_dir = Path(tempfile.mkdtemp(prefix="mmx_seg_deferred_")) if mp4_run_dir is None else mp4_run_dir
+                    tmp_dir.mkdir(parents=True, exist_ok=True)
+                    enc_path = tmp_dir / f"seg_{int(seg.index):04d}_fallback.mp4"
+                    from ..lib.video_export import write_frames_to_mp4
+                    write_frames_to_mp4(
+                        enc_path,
+                        chunk_frames.cpu().float(),
+                        fps=float(plan.frame_rate or 24.0),
+                        audio=chunk_audio if isinstance(chunk_audio, dict) and chunk_audio.get("waveform") is not None else None,
+                    )
+                    path = enc_path
+                except Exception as exc2:
+                    log.warning(
+                        "deferred_merge: fallback write_frames_to_mp4 seg %d failed (%s); "
+                        "this segment will be DROPPED from the merged mp4 (only its frames are in tensor output).",
+                        seg.index, exc2,
+                    )
+                    continue
+            seg_mp4_paths.append(Path(path))
+
+        if seg_mp4_paths:
+            try:
+                from .deferred_merge import deferred_merge_with_seam_reencode
+                merge_deferred_result = deferred_merge_with_seam_reencode(
+                    segment_mp4_paths=seg_mp4_paths,
+                    fps=float(plan.frame_rate or 24.0),
+                    seam_blending_enabled=seam_blending_user,
+                    continuity_enabled=continuity_enabled_for_seam,
+                    release_vram_fn=lambda: cleanup_segment_vram(enabled=True, unload_models=True, force_deep=True),
+                )
+            except Exception as exc:
+                log.warning("deferred_merge: Scheme A merge failed (%s); falling back to in-memory concat.", exc)
+                reports.append(
+                    f"⚠️ 延迟拼接失败（{exc}）；回退到「即时内存拼接」。"
+                )
+                merge_deferred_result = None
+                merge_mode = "即时内存拼接(默认)"  # fall through
+
+    if plan.export_mode == "all" and output_chunks and merge_mode == "仅分段导出不拼接":
+        reports.append(
+            "Merge mode: 仅分段导出不拼接 — kept per-segment MP4 on disk; "
+            "images output uses per-segment chunks layout (export_mode=segments compatible)."
+        )
+        # Do NOT run concat_continuous_chunks; treat layout like "segments" export.
+        # The executor return contract still requires a "combined" tensor for the
+        # images_pre_refine / finalize_director_outputs pathway; use first chunk.
+        combined = export_chunks[0]
+        pre_source = export_pre_chunks if export_pre_chunks else segment_pre_refine
+        if not pre_source:
+            pre_source = list(segment_outputs)
+        pre_combined = pre_source[0]
+        return (
+            combined,
+            segment_outputs,
+            segment_audios,
+            "\n".join(reports),
+            export_frame_counts,
+            pre_combined,
+            segment_pre_refine,
+        )
+
+    if merge_deferred_result is not None:
+        # ---- Scheme A merged: preview-only on tensor; full movie on disk ----
+        reports.append(
+            f"✅ 延迟拼接完成：最终视频保存在 {merge_deferred_result.merged_video_path} "
+            f"（{merge_deferred_result.total_frames} 帧 @ {merge_deferred_result.fps:.2f}fps）。"
+            f" ComfyUI images 输出仅返回前 {int(merge_deferred_result.preview_frames.shape[0])} 帧预览以节省内存。"
+        )
+        if merge_deferred_result.merge_script_path is not None:
+            reports.append(
+                f"合并脚本（双击可在 Windows 下重试）：{merge_deferred_result.merge_script_path}"
+            )
+        # combined = preview frames only (matches deferred_merge semantics from Plus)
+        combined = merge_deferred_result.preview_frames.cpu().float()
+        # segment_outputs stays as-is (run list chunks for "segments" export)
+        # Replace completed_audios with merged audio for the final AUDIO output.
+        if merge_deferred_result.merged_audio is not None:
+            try:
+                wav = merge_deferred_result.merged_audio.view(1, -1).cpu().float()
+                sr = int(merge_deferred_result.sample_rate or 24000)
+                segment_audios = [{"waveform": wav, "sample_rate": sr}] * max(1, len(segment_outputs))
+                export_frame_counts = [int(merge_deferred_result.total_frames)]
+            except Exception as exc:
+                log.warning("deferred_merge: merged audio formatting failed (%s).", exc)
+        pre_source = export_pre_chunks if export_pre_chunks else segment_pre_refine
+        if not pre_source:
+            pre_source = list(segment_outputs)
+        # images_pre_refine also uses preview (never return full movie tensor on Scheme A)
+        pre_combined = combined.clone()
+        return (
+            combined,
+            segment_outputs,
+            segment_audios,
+            "\n".join(reports),
+            export_frame_counts,
+            pre_combined,
+            segment_pre_refine,
+        )
+
+    # ---- 即时内存拼接(默认) ---- Original behavior preserved exactly.
     combined = concat_continuous_chunks(export_chunks, export_segments, plan)
     pre_source = export_pre_chunks if export_pre_chunks else segment_pre_refine
     if not pre_source:

--- a/director/gen_timeline.py
+++ b/director/gen_timeline.py
@@ -251,6 +251,7 @@ def build_gen_director_plan(
     width: int,
     height: int,
     ref_max_size: int,
+    lazy_source_clips: bool = True,
 ):
     """Build DirectorPlan for generation timeline modes (lazy import avoids cycles)."""
     from .plan import (
@@ -300,6 +301,21 @@ def build_gen_director_plan(
         task_key=task_key,
     )
 
+    # --- Early run selection: 先过滤"选中运行"的分段，再构建源剪辑，避免未选中段浪费显存 ---
+    run_sel = _parse_run_selection(timeline, len(segment_ranges))
+    filtered_segment_ranges = segment_ranges
+    if run_sel is not None:
+        run_set = set(int(i) for i in run_sel if 0 <= int(i) < len(segment_ranges))
+        if run_set:
+            filtered_segment_ranges = [
+                seg for i, seg in enumerate(segment_ranges) if i in run_set
+            ]
+            log.info(
+                "lazy_source early-filter: total %d segments → %d selected for run (skipping source-clip build for others)",
+                len(segment_ranges),
+                len(filtered_segment_ranges),
+            )
+
     if submode == "gen_blank":
         out_mode = "fixed"
         fw = int(output_block.get("width") or timeline.get("width") or width or 0)
@@ -339,23 +355,43 @@ def build_gen_director_plan(
     if is_prompt_batch_timeline(timeline, task_key) and not is_video_batch_task_key(task_key):
         export_mode = "all"
 
-    source_clips = _build_gen_source_clips(
-        segment_ranges,
-        task_key=task_key,
-        submode=submode,
-        edit_mode=edit_mode,
-        global_block=global_block,
-        height=out_h,
-        width=out_w,
-        output_mode=out_mode,
-        ref_max_size=ref_max,
-    )
+    # --- Lazy source clips 短路 ---
+    # t2v/r2v 任务中：生成不依赖"灰色占位源张量"（它来自refs/ref_videos/ref_audios）
+    # 但为了全量 50×192 帧源张量构建会造成 ~44.5GB 显存浪费，这里直接跳过。
+    # gen_blank 的 source clip 只是 0.5 灰色填充，永远不需要全量分配，无论 lazy_source_clips 是否开启
+    lazy_mode_active = submode == "gen_blank"
     attach_source_clips = is_prompt_batch_timeline(timeline, task_key) and task_key in ("i2i", "i2v")
-    if attach_source_clips:
-        # Placeholder timeline index only 鈥?spatial data comes from each segment's source_clip.
-        source_video = torch.full((len(source_clips), 16, 16, 3), 0.5, dtype=torch.float32)
+
+    if lazy_mode_active and not attach_source_clips:
+        total_seg = len(filtered_segment_ranges)
+        approx_gb = (total_seg * 192 * max(32, out_h) * max(32, out_w) * 3 * 4) / (1024 ** 3)
+        log.info(
+            "lazy_source_clips ENABLED: skipping %d seg × ~%df placeholder build (~%.1f GB saved). "
+            "t2v/r2v refs/ref_videos/ref_audios are still loaded per segment normally.",
+            total_seg,
+            192,
+            approx_gb,
+        )
+        source_clips = []  # 长度=0，后面 segment.source_clip 单独给空占位
+        # source_video 给一个极小占位，满足 segment_continuity 下游需要的 shape
+        source_video = torch.full((1, 16, 16, 3), 0.5, dtype=torch.float32)
     else:
-        source_video = cat_frames_variable_size(source_clips)
+        source_clips = _build_gen_source_clips(
+            filtered_segment_ranges,
+            task_key=task_key,
+            submode=submode,
+            edit_mode=edit_mode,
+            global_block=global_block,
+            height=out_h,
+            width=out_w,
+            output_mode=out_mode,
+            ref_max_size=ref_max,
+        )
+        if attach_source_clips:
+            # Placeholder timeline index only — spatial data comes from each segment's source_clip.
+            source_video = torch.full((len(source_clips), 16, 16, 3), 0.5, dtype=torch.float32)
+        else:
+            source_video = cat_frames_variable_size(source_clips)
 
     from .segment_continuity import resolve_segment_continuity_from_prev
 
@@ -457,7 +493,18 @@ def build_gen_director_plan(
                 idx + 1,
                 seg_task_key,
             )
-        seg_source = source_clips[idx].clone() if idx < len(source_clips) else None
+        if lazy_mode_active:
+            # 惰性模式：没有构建 source_clips，直接给每个段一个 1 帧的极小占位（不会被 t2v/r2v 使用）
+            seg_len = max(1, int(end) - int(start))
+            seg_source = torch.full((1, out_h, out_w, 3), 0.5, dtype=torch.float32)
+        else:
+            # 过滤后的 filtered 索引 → 原始 idx 映射
+            if run_sel is not None:
+                filtered_idx_map = {orig_i: fi for fi, orig_i in enumerate(sorted(run_sel)) if 0 <= orig_i < len(segment_ranges)}
+                fi = filtered_idx_map.get(idx)
+                seg_source = source_clips[fi].clone() if fi is not None and fi < len(source_clips) else None
+            else:
+                seg_source = source_clips[idx].clone() if idx < len(source_clips) else None
 
         segments.append(
             SegmentPlan(

--- a/director/plan.py
+++ b/director/plan.py
@@ -554,6 +554,7 @@ def build_director_plan(
     width: int,
     height: int,
     ref_max_size: int,
+    lazy_source_clips: bool = True,
 ) -> DirectorPlan:
     timeline: dict = {}
     if timeline_data and timeline_data.strip():
@@ -579,7 +580,7 @@ def build_director_plan(
     if task_key_early == "fl2v" or str(timeline.get("timelineMode") or "").lower() == "fl2v":
         from .fl2v_timeline import build_fl2v_director_plan
 
-        return build_fl2v_director_plan(
+        plan = build_fl2v_director_plan(
             timeline,
             global_task_type=task_type,
             global_prompt=prompt,
@@ -589,8 +590,10 @@ def build_director_plan(
             height=height,
             ref_max_size=ref_max_size,
         )
+        plan.lazy_source_clips = bool(lazy_source_clips)
+        return plan
     if is_gen_timeline(timeline, task_key_early):
-        return build_gen_director_plan(
+        plan = build_gen_director_plan(
             timeline,
             global_task_type=task_type,
             global_prompt=prompt,
@@ -599,7 +602,10 @@ def build_director_plan(
             width=width,
             height=height,
             ref_max_size=ref_max_size,
+            lazy_source_clips=lazy_source_clips,
         )
+        plan.lazy_source_clips = bool(lazy_source_clips)
+        return plan
 
     frame_map = logical_frame_map(timeline)
     source_total = logical_frame_count(timeline) or int(timeline.get("totalFrames") or total_frames or 0)

--- a/director/segment_runtime.py
+++ b/director/segment_runtime.py
@@ -29,7 +29,10 @@ def resolve_segment_raw_clip(plan: DirectorPlan, seg) -> torch.Tensor:
         return seg.source_clip.clone()
 
     # Pure t2v (incl. external groups) has no source frames.
-    if getattr(seg, "task_key", "") == "t2v":
+    # r2v/r2i: real data comes from refs / ref_videos / ref_audios, not gray source canvas.
+    #   When lazy_source_clips is ON (or external pack path), skip slicing source_video.
+    task_key = getattr(seg, "task_key", "")
+    if task_key in ("t2v", "r2v", "r2i"):
         return torch.zeros((0, 16, 16, 3), dtype=torch.float32)
 
     # fl2v end-only: plan leaves source_clip=None on purpose. Do not slice the
@@ -70,7 +73,8 @@ def resolve_segment_raw_clip_with_lookahead(
         # Gen canvases have no timeline lookahead beyond the clip itself.
         return seg.source_clip.clone()
 
-    if getattr(seg, "task_key", "") == "fl2v" and is_gen_timeline_plan(plan):
+    task_key = getattr(seg, "task_key", "")
+    if task_key in ("t2v", "r2v", "r2i", "fl2v") and is_gen_timeline_plan(plan):
         return torch.zeros((0, 16, 16, 3), dtype=torch.float32)
 
     end = int(seg.end_frame) + extra

--- a/director/vram_cleanup.py
+++ b/director/vram_cleanup.py
@@ -1,30 +1,198 @@
-"""Release GPU memory between MiniMax H3 Director segment runs."""
+"""Release GPU & system memory between MiniMax H3 Director segment runs.
+
+This module mirrors the "pressure-aware cleanup" from the PRO/Plus studio node so
+that the Director (non-Plus) also survives long runs (≥20 segments) on machines
+with limited RAM / pagefile. The single most important change is a RAM pressure
+probe (via psutil) before each cleanup call: when free system memory drops below
+a safety threshold or used-RAM % crosses 88%, the cleanup is upgraded to a
+*deep* pass (unload ALL staged models) so 49GB TE staged memory can actually be
+returned to the OS.
+"""
 
 from __future__ import annotations
 
 import gc
 import logging
+import os
+from typing import Any
 
 log = logging.getLogger("ComfyUI-MiniMaxH3-Director.director.vram")
 
+# ---------------------------------------------------------------------------
+# Memory snapshot (mirrors Plus studio_node._memory_snapshot)
+# ---------------------------------------------------------------------------
 
-def cleanup_segment_vram(*, enabled: bool = True, unload_models: bool = True) -> None:
-    """Release segment GPU memory: gc, optional unload of ComfyUI models, empty CUDA cache."""
+def memory_snapshot() -> dict[str, Any]:
+    """Read current RAM / VRAM status; returns dict with pressure flag.
+
+    pressure=True triggers deep release to prevent staged model memory from
+    being starved out of system pagefile. Mirrors Plus thresholds:
+        reserve  = min(8GB, max(3GB, 18% of total RAM))
+        pressure = available < reserve  OR  percent >= 88%
+    """
+    snap: dict[str, Any] = {
+        "ram_total": None,
+        "ram_available": None,
+        "ram_percent": None,
+        "ram_reserve": None,
+        "vram_free": None,
+        "pressure": False,
+    }
+    try:
+        import psutil  # type: ignore
+
+        vm = psutil.virtual_memory()
+        total = int(vm.total)
+        available = int(vm.available)
+        reserve = int(min(8 * 1024 ** 3, max(3 * 1024 ** 3, total * 0.18)))
+        snap.update({
+            "ram_total": total,
+            "ram_available": available,
+            "ram_percent": float(vm.percent),
+            "ram_reserve": reserve,
+            "pressure": available < reserve or float(vm.percent) >= 88.0,
+        })
+    except Exception:
+        pass
+    try:
+        import comfy.model_management as mm  # type: ignore
+
+        snap["vram_free"] = int(mm.get_free_memory())
+    except Exception:
+        pass
+    return snap
+
+
+def _format_snap(snap: dict[str, Any]) -> str:
+    parts: list[str] = []
+    if snap.get("ram_total") is not None:
+        gb = lambda v: v / 1024 ** 3  # noqa: E731
+        parts.append("RAM %.1f/%.1fGB (%.0f%%, avail %.1fGB)" % (
+            gb(snap["ram_total"] - snap["ram_available"]),
+            gb(snap["ram_total"]),
+            snap["ram_percent"],
+            gb(snap["ram_available"]),
+        ))
+    if snap.get("vram_free") is not None:
+        parts.append("VRAM free %.1fGB" % (snap["vram_free"] / 1024 ** 3))
+    if snap.get("pressure"):
+        parts.append("PRESSURE=ON")
+    return " | ".join(parts) if parts else "memory state unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Loaded-model counter (for logs only)
+# ---------------------------------------------------------------------------
+
+def _loaded_model_count() -> int | None:
+    try:
+        import comfy.model_management as mm  # type: ignore
+
+        loaded = mm.loaded_models()
+        return len(loaded) if loaded is not None else None
+    except Exception:
+        return None
+
+# ---------------------------------------------------------------------------
+# Main cleanup — pressure-aware.  Keep the legacy signature so callers inside
+# executor_core (which pass `unload_models=` style semantics) still work.
+# ---------------------------------------------------------------------------
+
+def cleanup_segment_vram(
+    *,
+    enabled: bool = True,
+    unload_models: bool = True,
+    force_deep: bool = False,
+    segment_index: int | None = None,
+) -> None:
+    """Release segment GPU + system memory.
+
+    Parameters
+    ----------
+    enabled:
+        Master kill switch (False = no-op).
+    unload_models:
+        Legacy flag — when True (the default), at least a model-keep-loaded
+        (cache-only) pass is performed; actual unload is decided by pressure.
+    force_deep:
+        Override pressure probe and always do the deepest cleanup.  Used by
+        deferred_merge just before the ffmpeg-based final pass.
+    segment_index:
+        Optional, used only for log lines so operators can tell which
+        segment boundary caused a pressure-elevated cleanup.
+    """
     if not enabled:
         return
-    gc.collect()
+
+    snap = memory_snapshot()
+    deep = force_deep or bool(snap.get("pressure"))
+    before = _loaded_model_count()
+
+    # Pass 1: light GC (reference cycle collection) before touching mm APIs.
+    # Two generations + return-to-system to shake out large mmap'd staged areas.
+    gc.collect(0)
+    gc.collect(1)
+    gc.collect(2)
+
+    # Aggressively trim python process working set (Windows / Linux) so staged
+    # weight mmaps can be physically evicted.  Without this, 49GB TE staged
+    # memory accumulates across segments and crashes the next fopen/fread on
+    # pagefile-backed weight files (the exact crash the user saw on seg #14).
     try:
-        import comfy.model_management as mm
+        if os.name == "nt":
+            import ctypes  # type: ignore
+
+            # SetProcessWorkingSetSize with (-1,-1) tells the kernel to trim
+            # all possible pages back to the working-set minimum.
+            kernel32 = ctypes.windll.kernel32
+            HANDLE = ctypes.c_void_p
+            SIZE_T = ctypes.c_size_t
+            kernel32.SetProcessWorkingSetSizeEx.restype = ctypes.c_int
+            kernel32.SetProcessWorkingSetSizeEx.argtypes = [HANDLE, SIZE_T, SIZE_T, ctypes.c_ulong]
+            hProc = ctypes.c_void_p(-1)  # GetCurrentProcess() pseudo-handle
+            kernel32.SetProcessWorkingSetSizeEx(hProc, SIZE_T(-1), SIZE_T(-1), 0)
+    except Exception:
+        # Never crash the whole run just because trim failed.
+        pass
+
+    try:
+        import comfy.model_management as mm  # type: ignore
 
         mm.cleanup_models_gc()
-        if unload_models:
-            mm.unload_all_models()
-            mm.cleanup_models()
+        if deep and unload_models:
+            try:
+                mm.unload_all_models()
+            except Exception as exc:
+                log.warning("Segment VRAM deep unload failed (%s); continuing with cache clear.", exc)
+        mm.cleanup_models()
         mm.soft_empty_cache()
     except Exception as exc:
         log.warning("Segment VRAM cleanup failed: %s", exc)
         return
-    if unload_models:
-        log.debug("MiniMax H3 Director: segment VRAM cleanup (models unloaded, cache cleared)")
+
+    # Pass 2: final GC round after mm has released all references.
+    gc.collect(2)
+    try:
+        if os.name == "nt":
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            kernel32.SetProcessWorkingSetSizeEx(
+                ctypes.c_void_p(-1), ctypes.c_size_t(-1), ctypes.c_size_t(-1), 0)
+    except Exception:
+        pass
+
+    after = _loaded_model_count()
+    seg_tag = f" (seg {segment_index})" if segment_index is not None else ""
+    if deep:
+        count_note = ""
+        if before is not None and after is not None:
+            count_note = f", models {before}->{after}"
+        log.info(
+            "Segment VRAM cleanup: DEEP release%s%s; %s",
+            seg_tag, count_note, _format_snap(snap),
+        )
     else:
-        log.debug("MiniMax H3 Director: segment VRAM cleanup (cache cleared, models kept loaded)")
+        log.debug(
+            "Segment VRAM cleanup: light pass%s; %s",
+            seg_tag, _format_snap(snap),
+        )

--- a/nodes/director.py
+++ b/nodes/director.py
@@ -196,6 +196,11 @@ class MiniMaxH3Director:
         shift_video=12.0,
         shift_audio=3.0,
         clear_vram_between_segments=True,
+        deep_unload_between_segments=False,
+        lazy_source_clips=True,
+        merge_mode="即时内存拼接(默认)",
+        max_segments_per_merge=15,
+        seam_blending=True,
         export_source_images=False,
         **kwargs,
     ):
@@ -214,6 +219,10 @@ class MiniMaxH3Director:
             i2v_groups=i2v_groups,
             r2v_groups=r2v_groups,
             refine=refine,
+            lazy_source_clips=lazy_source_clips,
+            merge_mode=merge_mode,
+            max_segments_per_merge=max_segments_per_merge,
+            seam_blending=seam_blending,
         )
 
         combined, segment_outputs, segment_audios, report, export_frame_counts, pre_combined, pre_segments = (
@@ -232,6 +241,7 @@ class MiniMaxH3Director:
                 shift_video=shift_video,
                 shift_audio=shift_audio,
                 clear_vram_between_segments=clear_vram_between_segments,
+                deep_unload_between_segments=deep_unload_between_segments,
             )
         )
 

--- a/nodes/director_common.py
+++ b/nodes/director_common.py
@@ -86,6 +86,58 @@ def director_perf_inputs() -> dict:
                 "tooltip": "段间清理显存：每段结束后卸载模型并清空 CUDA 缓存。",
             },
         ),
+        "deep_unload_between_segments": (
+            "BOOLEAN",
+            {
+                "default": False,
+                "tooltip": (
+                    "每段后深度卸载模型（关=自适应：默认仅当RAM≥88%时才deep；\n"
+                    "开=每段结束都强制unload_all_models，内存安全但每段重新加载模型会更慢）。\n"
+                    "对应Plus版「每段后卸载模型」开关。"
+                ),
+            },
+        ),
+        "lazy_source_clips": (
+            "BOOLEAN",
+            {
+                "default": True,
+                "tooltip": (
+                    "惰性加载源张量（默认开）：t2v/r2v 任务跳过灰色占位张量的批量构建，"
+                    "避免 50 段×192 帧≈44.5GB 的显存峰值导致 OOM 崩溃。"
+                    "r2v 的实际生成数据来自参考图/视频/音频，不依赖占位张量。"
+                    "关闭则恢复原始行为（一次性构建所有分段的源张量）。"
+                ),
+            },
+        ),
+        "merge_mode": (
+            ["即时内存拼接(默认)", "延迟拼接(省内存+接缝修缝)", "仅分段导出不拼接"],
+            {
+                "default": "即时内存拼接(默认)",
+                "tooltip": (
+                    "全部导出时的拼接模式：\n"
+                    "・即时内存拼接：所有段生成完后在内存中 concat（段数多时 OOM，支持 seam_blending）\n"
+                    "・延迟拼接(省内存+接缝修缝)：逐段存 MP4→释放显存→仅接缝24帧重编码修缝+ffmpeg copy拼接（段数无上限，画质无损）\n"
+                    "・仅分段导出不拼接：只输出各段 MP4，不合并"
+                ),
+            },
+        ),
+        "max_segments_per_merge": (
+            "INT",
+            {
+                "default": 15,
+                "min": 2,
+                "max": 200,
+                "step": 1,
+                "tooltip": "延迟拼接降级为方案B(轮内全量解码)时每轮最大段数（仅回退路径使用）。",
+            },
+        ),
+        "seam_blending": (
+            "BOOLEAN",
+            {
+                "default": True,
+                "tooltip": "延迟拼接时启用接缝修缝：每接缝仅解码24帧做像素级曝光/桥接（开启推荐，内存<1GB）。",
+            },
+        ),
         "export_source_images": (
             "BOOLEAN",
             {
@@ -165,6 +217,10 @@ def prepare_director_plan(
     i2v_groups=None,
     r2v_groups=None,
     refine=None,
+    lazy_source_clips: bool = True,
+    merge_mode: str = "即时内存拼接(默认)",
+    max_segments_per_merge: int = 15,
+    seam_blending: bool = True,
 ):
     from ..director.external_groups import (
         build_plan_from_external_groups,
@@ -207,6 +263,11 @@ def prepare_director_plan(
             ref_max_size=ref_max_size,
         )
         plan = _attach_refine(plan, refine)
+        # 将拼接/惰性加载参数挂到 plan 上（executor_core 会读取）
+        plan.lazy_source_clips = bool(lazy_source_clips)
+        plan.merge_mode = str(merge_mode)
+        plan.max_segments_per_merge = int(max_segments_per_merge)
+        plan.seam_blending = bool(seam_blending)
         log.info(
             "MiniMax H3 Director: external %s groups × %d (task=%s) | %s",
             family,
@@ -231,8 +292,14 @@ def prepare_director_plan(
         width=width,
         height=height,
         ref_max_size=ref_max_size,
+        lazy_source_clips=lazy_source_clips,
     )
     plan = _attach_refine(plan, refine)
+    # 将拼接/惰性加载参数挂到 plan 上（executor_core 会读取）
+    plan.lazy_source_clips = bool(lazy_source_clips)
+    plan.merge_mode = str(merge_mode)
+    plan.max_segments_per_merge = int(max_segments_per_merge)
+    plan.seam_blending = bool(seam_blending)
     log.info(plan_summary(plan).replace("\n", " | "))
     return plan
 

--- a/web/js/minimax_i18n.js
+++ b/web/js/minimax_i18n.js
@@ -370,6 +370,11 @@ const ZH = {
 
     "widget.seed": "种子",
     "widget.clearVram": "段间清理显存",
+    "widget.deepUnload": "每段深度卸载模型",
+    "widget.lazySourceClips": "惰性加载源张量",
+    "widget.mergeMode": "全部导出拼接模式",
+    "widget.maxSegPerMerge": "每轮合并段数(备用)",
+    "widget.seamBlending": "接缝修缝(延迟拼接)",
     "widget.exportSourceImages": "输出原片对比",
     "widget.grpSample": "采样设置",
     "toolbar.batchDetailSolo": "单显模式",
@@ -392,6 +397,24 @@ const ZH = {
     "widget.controlAfterGenerate": "生成前后定制",
     "widget.tooltip.clearVram": "段间清理显存：每段结束后卸载模型并清空 CUDA 缓存。",
     "widget.tooltip.exportSourceImages": "输出原片对比（时间轴原片帧对比）。默认关以节省内存。",
+    "widget.tooltip.deepUnload": (
+        "每段后强制深度卸载模型（关闭=默认仅当RAM≥88%才deep；" +
+        "开启=每段都unload_all_models，最安全但每段重新加载模型会慢几秒）。" +
+        "对应Plus版「每段后卸载模型」开关。"
+    ),
+    "widget.tooltip.lazySourceClips": (
+        "惰性加载源张量（默认开）：t2v/r2v 任务跳过灰色占位张量的批量构建，" +
+        "避免 50 段×192 帧≈44.5GB 的显存峰值造成 OOM 崩溃。" +
+        "r2v 实际数据来自参考图/视频/音频，不依赖占位源张量。"
+    ),
+    "widget.tooltip.mergeMode": (
+        "全部导出时的拼接模式：\n" +
+        "・即时内存拼接(默认)：所有段生成完后在内存中 concat（段数多时可能 OOM）\n" +
+        "・延迟拼接(省内存+接缝修缝)：逐段存 MP4→释放显存→仅接缝 24 帧做重编码修缝→ffmpeg copy 拼接（段数无上限，画质无损）\n" +
+        "・仅分段导出不拼接：只输出各段 MP4，不合并"
+    ),
+    "widget.tooltip.maxSegPerMerge": "延迟拼接的备用方案(轮内全量解码)时，每轮最多合并多少段。仅在方案 A 内部异常回退时生效。",
+    "widget.tooltip.seamBlending": "延迟拼接时启用接缝修缝：仅解码接缝两侧 12 帧做曝光平滑/桥接（内存<1GB，推荐开启）。",
     "common.upload": "选择/上传",
     "common.clickUpload": "点击选择/上传",
     "batch.delete": "删除",
@@ -793,6 +816,11 @@ const EN = {
 
     "widget.seed": "Seed",
     "widget.clearVram": "Clear VRAM between segments",
+    "widget.deepUnload": "Force unload models per segment",
+    "widget.lazySourceClips": "Lazy source clips",
+    "widget.mergeMode": "Merge mode (all export)",
+    "widget.maxSegPerMerge": "Segments per merge round (fallback)",
+    "widget.seamBlending": "Seam blending (deferred merge)",
     "widget.exportSourceImages": "Export source comparison (source_images)",
     "widget.grpSample": "Sampling settings",
     "toolbar.batchDetailSolo": "Solo mode",
@@ -814,6 +842,24 @@ const EN = {
     "widget.grpPerf": "Performance",
     "widget.controlAfterGenerate": "Control after generate",
     "widget.tooltip.clearVram": "Clear VRAM between segments: unload models and empty CUDA cache after each segment.",
+    "widget.tooltip.deepUnload": (
+        "Force a FULL unload of all staged models after EVERY segment " +
+        "(off = auto: deep only when RAM ≥ 88%; on = safest but reloading each segment adds seconds)." +
+        "Matches Plus \"Unload models after each segment\" switch."
+    ),
+    "widget.tooltip.lazySourceClips": (
+        "Lazy source clips (default on). For t2v/r2v tasks skip building the full gray-canvas " +
+        "placeholder tensor (50 seg × 192f ≈ 44.5 GB) that is never actually consumed — r2v uses " +
+        "refs/ref_videos/ref_audios, not the placeholder. Turn off for the old one-shot behaviour."
+    ),
+    "widget.tooltip.mergeMode": (
+        "Merge strategy used when export mode = all:\n" +
+        "・Immediate in-memory concat (default): high memory, full seam blending.\n" +
+        "・Deferred merge (low memory + seam repair): flush per-seg MP4 → drop VRAM → local 24-frame seam re-encode → lossless ffmpeg stream copy. No segment count limit.\n" +
+        "・Segments only (no merge): keep per-segment MP4 on disk; do not combine."
+    ),
+    "widget.tooltip.maxSegPerMerge": "Fallback path: max segments per full-decode round. Only used when Scheme A raises an internal error.",
+    "widget.tooltip.seamBlending": "During deferred merge, decode only 12 frames on each side of every seam and re-run seam_blending (exposure smoothing + micro bridge). <1 GB memory. Recommended.",
     "widget.tooltip.exportSourceImages": "Export source_images (timeline source-frame comparison). Off by default to save memory.",
     "common.upload": "Choose/Upload",
     "common.clickUpload": "Click to choose/upload",

--- a/web/js/minimax_timeline.js
+++ b/web/js/minimax_timeline.js
@@ -417,6 +417,11 @@ const HIDDEN_WIDGETS = [
 const DIRECTOR_WIDGET_LABEL_KEYS = {
     seed: "widget.seed",
     clear_vram_between_segments: "widget.clearVram",
+    deep_unload_between_segments: "widget.deepUnload",
+    lazy_source_clips: "widget.lazySourceClips",
+    merge_mode: "widget.mergeMode",
+    max_segments_per_merge: "widget.maxSegPerMerge",
+    seam_blending: "widget.seamBlending",
     export_source_images: "widget.exportSourceImages",
     control_after_generate: "widget.controlAfterGenerate",
     "control after generate": "widget.controlAfterGenerate",
@@ -424,6 +429,11 @@ const DIRECTOR_WIDGET_LABEL_KEYS = {
 
 const DIRECTOR_WIDGET_TOOLTIP_KEYS = {
     clear_vram_between_segments: "widget.tooltip.clearVram",
+    deep_unload_between_segments: "widget.tooltip.deepUnload",
+    lazy_source_clips: "widget.tooltip.lazySourceClips",
+    merge_mode: "widget.tooltip.mergeMode",
+    max_segments_per_merge: "widget.tooltip.maxSegPerMerge",
+    seam_blending: "widget.tooltip.seamBlending",
     export_source_images: "widget.tooltip.exportSourceImages",
 };
 
@@ -1192,7 +1202,16 @@ function moveDirectorDomWidgetToEnd(node) {
     node.widgets.push(widget);
 }
 
-const PERF_WIDGET_ORDER = ["bd_grp_perf", "clear_vram_between_segments", "export_source_images"];
+const PERF_WIDGET_ORDER = [
+    "bd_grp_perf",
+    "clear_vram_between_segments",
+    "deep_unload_between_segments",
+    "lazy_source_clips",
+    "merge_mode",
+    "max_segments_per_merge",
+    "seam_blending",
+    "export_source_images",
+];
 
 function moveDirectorPerfWidgetsBeforeTimeline(node) {
     const dom = node?._minimaxDomWidget;


### PR DESCRIPTION
## 一、基础版目录下修改的所有文件
| 文件 | 主要改动 |
|------|---------|
| `director/deferred_merge.py` | 方案A拼接重做：帧精确+流式，消除跳帧；音频维度；修缝uint8范围；辅助工具函数修复 | | `director/gen_timeline.py` | gen_blank 跳过灰色占位张量全量分配，杜绝 47GB OOM | | `nodes/director.py` + `nodes/director_common.py` | 新增 4 个性能控制 widget 及 plan 传递 |

---

## 二、性能控制新增的 4 个设置

这 4 个 widget 都在节点的 **「性能」分组（BD_GRP_PERF）**。

### 2.1 `lazy_source_clips` — 惰性加载源张量

- **代码位置**：`nodes/director_common.py#L100-L110`
- **类型**：BOOLEAN
- **默认值**：`True`（开启，推荐保持）

#### 优化内容

t2v / r2v 任务中，`_build_gen_source_clips()` 原本会为每一段构建一份 `torch.full((frame_count, H, W, 3), 0.5, dtype=torch.float32)` 的 **灰色占位张量**。 但实际生成时 r2v 的输入来自 `refs / ref_videos / ref_audios`，**根本不会读取这份全量灰色数据**； 关闭惰性加载时，50 段 × 192 帧 × 1376×768 × 3 × 4B ≈ **44.5 GB**，直接造成：

```
RuntimeError: [enforce fail at alloc_cpu.cpp:117] data.
DefaultCPUAllocator: not enough memory: you tried to allocate 47174123520 bytes.
```

开启后：
1. `gen_blank` 子模式下 **不再分配任何灰色占位帧张量**；
2. 只给下游一个 `(1, 16, 16, 3)` 的极小张量做 shape 检查；
3. 实际生成需要的 ref / ref_video / ref_audio 仍按段正常加载，完全不影响结果。

> 本次额外兜底：`lazy_mode_active = submode == "gen_blank"` 直接改为 **无条件短路**，
> 无论 `lazy_source_clips` 是否开启，`gen_blank` 都不会分配 44GB 灰色占位。
> 位置：`director/gen_timeline.py#L361`。

**建议：保持开启。**

---

### 2.2 `merge_mode` — 拼接模式

- **代码位置**：`nodes/director_common.py#L112-L122`
- **类型**：三选一
- **默认值**：`即时内存拼接(默认)`
- **推荐值**：`延迟拼接(省内存+接缝修缝)`

#### 三种模式对比

| 模式 | 实现原理 | 内存峰值 | 帧精确 | 接缝修缝 24f | 段数上限 | 产物 |
|------|---------|---------|-------|-------------|---------|------| | 即时内存拼接(默认) | 全部段解码到 GPU → tensor concat | 极高，段数>10容易OOM | ✅ | ✅ | 受显存限制 | ComfyUI tensor 返回 | | **延迟拼接(省内存+接缝修缝)** | 逐段存 MP4 → 释放显存 → 方案A精确/流式单文件编码 | **低且恒定** | ✅ | ✅ | **任意段数** | `deferred_merged_a_{precise/stream}_YYYYMMDD_HHMMSS.mp4` | | 仅分段导出不拼接 | 只输出每段 MP4，不做合并 | 低 | — | — | 无 | `*_segN_*.mp4` 一堆分段文件 |

#### 方案A内部三档自动切换（用户不需要手动选）

方案A入口会按「总帧数」自动选择最优路径：

| 总帧数 | 自动模式 | 内存峰值 1376×768 | 帧精确 | 接缝修缝 | 输出文件名 | |--------|---------|-----------------|-------|---------|-----------| | ≤ 4000（≈17段×10s @24fps） | 精确模式（全量 uint8 CPU 拼接 + 一次性编码） | ≤ 10.8 GB | ✅ | ✅ 24帧 blending + 10ms 音频 crossfade | `deferred_merged_a_precise_*.mp4` | | > 4000 | 流式模式（逐段解码 → ffmpeg pipe → 释放） | **≈ 700 MB（恒定，与段数无关）** | ✅ | ✅ 24帧 blending + 10ms 音频 crossfade | `deferred_merged_a_stream_*.mp4` | | 两路异常兜底 | 老切片版（-ss/-t + concat copy） | 低，但 ±1 帧误差 | ❌ | ✅ | `deferred_merged_a_*.mp4` |

#### 效果 vs 老方案A（跳帧版）的本质改进

1. **帧精确性**：废弃 `ffmpeg -ss 时间戳 -t 时长` 的浮点切片（±1帧误差）， 直接用 tensor 整数索引 `[start:end]`，零丢失零重复。
2. **PTS 连续性**：废弃「多个独立编码 MP4 → ffmpeg concat -c copy」的拼接 （多段各自独立时间戳/GOP，粘在一起播放器见时间戳跳变造成视觉"跳帧/卡顿"）， 改为 **全量帧 → 一次性调用 ffmpeg 编码成单个 MP4**，PTS 一条直线。
3. **接缝修缝**：仍然保留 `_run_seam_blending_a` 的 24 帧像素级平滑 （additive opening luma 曝光桥接等）和 `_audio_crossfade_short` 的 10ms 线性音频淡入淡出，**和创作界面合并相比多了接缝修缝**。
4. **修缝像素范围 bug 修复**：`_run_seam_blending_a` 内部使用 `.clamp(0.0, 1.0)`，之前直接塞 `uint8[0,255]` 进去会全部被截断到 1 → 画面全白。修缝前改为 `uint8 → float() / 255.0`，修缝后再 `* 255 → uint8 clamp`，回值正确。
5. **音频维度统一**：`_decode_audio_range` 返回 `(1, 1, N)` 3D 张量， 之前 body 音频 `[audio_start:audio_end]` 切出来仍为 3D，而 seam 音频经 `_audio_crossfade_short` `.view(-1)` 后为 1D，导致 `torch.cat(audio_parts)` 维度不匹配报错。现已在所有 decode 点之后立即 `.view(-1)` 展平为 1D，输出时再 `view(1,1,-1)` 回 ComfyUI 格式。

**建议：选「延迟拼接(省内存+接缝修缝)」——段数/分辨率再高也不崩，效果最好。**

---

### 2.3 `max_segments_per_merge` — 每轮合并段数

- **代码位置**：`nodes/director_common.py#L124-L132`
- **类型**：INT，范围 `[2, 200]`
- **默认值**：`15`
- **现在还有用吗？——几乎不用，但作为最后兜底保留**

#### 最初的设计用途（旧时代）

方案A老实现是「时间戳切片 + concat copy」，段多了跳帧误差会累积，因此
「每 15 段先合并成一个中间 MP4（h3_round_*.mp4），再把各轮的中间产物合并成
最终 MP4」，每轮的误差上限被限制在 15 段内，不会随段数线性恶化。

#### 当前方案A下的实际使用

新的精确/流式模式：
- **精确模式 ≤ 4000 帧**：一次性拼所有段，整数索引零累积误差，不需要分批；
- **流式模式 > 4000 帧**：逐段写 pipe，峰值内存恒定（700MB 量级），段数与 内存/误差都没有相关性，也不需要分批；
- **只有当精确/流式两路都因异常（ffmpeg找不到、源编码格式非avc1等） 回退到旧方案B（轮内全量解码）时**，才会按 `max_segments_per_merge` 每轮段数分批合并。

**建议：默认 15 不用改，仅作异常路径兜底。**

---

### 2.4 `deep_unload_between_segments` — 每段后深度卸载模型

- **代码位置**：`nodes/director_common.py#L89-L98`
- **类型**：BOOLEAN
- **默认值**：`False`（自适应模式）
- **配合项**：`clear_vram_between_segments`（段间清理，默认开启， `nodes/director_common.py#L82-L87`）

#### 两级清理的行为

| 段间清理<br>`clear_vram_between_segments` | 深度卸载<br>`deep_unload_between_segments` | 行为 | 内存安全 | 速度 | |---|---|---|---|---|
| ✅ 开（默认） | ❌ 关（默认） | **自适应清理**：每段结束 `soft_empty_cache` 清 CUDA 缓存；<br>**当内存压力触发**（RAM≥82% 或 可用内存 < reserve）时再 `unload_all_models()` 深度卸载 | 中高（安全阈值已收紧） | 快（大部分段不需要重载模型） | | ✅ 开 | ✅ 开 | **强制深度卸载**：每段结束都 `unload_all_models()` 彻底卸载 TE/VAE/文本编码器等全部模型；<br>下一段重新加载 | 最高（24+段跑一天也稳定） | 慢（每段多花几秒加载模型） | | ❌ 关 | ❌ 关 | 不执行清理；所有模型常驻 | 最低（段数多极易 OOM / AIMDO hostbuf 刷屏） | 最快 |

#### 自适应压力阈值（本次修复收紧）

- 代码位置：自适应逻辑位于节点段间回调 `_segment_boundary_cleanup`
- 判定条件（满足任一即触发深度卸载）：
  1. `ram_percent >= 82%`（之前 88%）；
  2. `ram_available < ram_reserve`。
- `ram_reserve` 规则：
  - **之前**：`max(3 GB, min(8 GB, total_ram * 18%))`
  - **现在**：`max(6 GB, min(12 GB, total_ram * 25%))`

#### 解决的 AIMDO hostbuf 刷屏错误

H3 模型加载器会预留一块专用的"CPU 钉住内存池（≈25.4 GB，供 TE 模型分页走 CPU↔GPU DMA）"。 这个池的消耗在系统层面只计为"已占用内存"，不会体现为 free 不足；
旧阈值（88% / 3GB / 18%）下，系统还剩 6 GB free 时自适应判定为"健康"，
但钉住内存池已经被 TE 分页占满，段 12 之后会刷屏：

```
[ERROR] aimdo: src/hostbuf.c:46:ERROR:hostbuf_grow: requested 27372122112 bytes
        beyond reserved host buffer 27286503424
```

阈值收紧到 82% / 6GB / 25% 后，**在钉住内存池见底前就提前强制 unload_all_models**， 彻底清空模型分页，下一段拿到"干净的钉住内存池"，AIMDO 错误不会再刷屏。

#### 建议

- 24 段以内、物理内存 ≥ 32 GB：保持默认自适应即可；
- 30+ 段或控制台出现 `aimdo hostbuf_grow`：**开启强制深度卸载**。

---

## 三、`director/deferred_merge.py` 早期累积修复

除方案A精确/流式的大改动外，还包含以下早期小修复，一并记录：

| # | 位置 | 改动 | 解决问题 |
|---|------|------|---------|
| 1 | `_slice_mp4_piece` | ffmpeg 命令加 `-r fps` 强制输出帧率一致 | 段间帧率微差，拼接后PTS不连续 | | 2 | head / tail 切片 | **仅对非最后段创建 head 切片**；最后段 tail 直接包含所有尾帧 | 最终产物时长加倍（20s → 30s），头尾重复段 | | 3 | `_audio_crossfade_short` | 输出长度公式修正，与 seam 帧×spf 严格对齐 | 接缝处音频长/短 1~2 个采样，长视频累积漂移 | | 4 | `_write_seam_piece_mp4` | 增加 ffmpeg `returncode != 0` 检查并抛异常 | 编码静默失败，拼接后续读空 MP4 导致黑帧 |

---

## 四、快速推荐配置（抄作业）

想"效果=创作界面合并以上（有接缝修缝）、不崩、内存稳"，直接套用：

| 设置 | 值 |
|------|---|
| 段间清理显存（clear_vram_between_segments） | ✅ 开（默认） |
| 每段后深度卸载模型（deep_unload） | 自适应（默认）；段数多/出现 `aimdo hostbuf_grow` → ✅ 开 | | 惰性加载源张量（lazy_source_clips） | ✅ 开（默认） |
| 拼接模式（merge_mode） | **延迟拼接(省内存+接缝修缝)** |
| 每轮合并段数（max_segments_per_merge） | 15（默认不动，异常兜底用） |