### PR TITLE
性能优化：降低导演节点内存占用并刷新缓存状态

### DIFF
--- a/director/audio_export.py
+++ b/director/audio_export.py
@@ -26,6 +26,15 @@ AUDIO_MODE_MUTE = "mute"
 VIDEO_EDIT_AUDIO_TASKS = frozenset({"v2v", "rv2v"})
 
 
+def _execution_audio_cache(plan) -> dict[str, dict[str, Any]]:
+    """PCM cache owned by this DirectorPlan/current execution only."""
+    cache = getattr(plan, "audio_decode_cache", None)
+    if not isinstance(cache, dict):
+        cache = {}
+        setattr(plan, "audio_decode_cache", cache)
+    return cache
+
+
 def task_passes_source_audio(task_key: str) -> bool:
     # v2v/rv2v: source-timeline extract; others may fall back after empty model audio.
     return task_key in {"i2v", "fl2v", "r2v", "v2v", "rv2v"}
@@ -94,7 +103,13 @@ def prepare_segment_audio_for_file_export(
         timeline = getattr(plan, "raw", None) or {}
         start = int(getattr(seg, "start_frame", 0) or 0)
         end = int(getattr(seg, "end_frame", start + n_frames) or (start + n_frames))
-        extracted = extract_timeline_audio(timeline, start, end, fps)
+        extracted = extract_timeline_audio(
+            timeline,
+            start,
+            end,
+            fps,
+            audio_cache=_execution_audio_cache(plan),
+        )
         if _audio_has_samples(extracted):
             sr = int(extracted.get("sample_rate") or SILENT_SAMPLE_RATE)
             return _pad_or_trim_audio_to_frames(
@@ -377,7 +392,13 @@ def build_director_audio_outputs(
                 outputs.append(empty_audio_dict(silent_sample_rate))
                 continue
             seg = plan.segments[seg_indices[i]]
-            extracted = extract_timeline_audio(timeline, seg.start_frame, seg.end_frame, fps)
+            extracted = extract_timeline_audio(
+                timeline,
+                seg.start_frame,
+                seg.end_frame,
+                fps,
+                audio_cache=_execution_audio_cache(plan),
+            )
             if mode == AUDIO_MODE_SOURCE and not _audio_has_samples(extracted):
                 hint = diagnose_source_audio_failure(
                     timeline, seg.start_frame, seg.end_frame, fps
@@ -402,7 +423,17 @@ def build_director_audio_outputs(
     end = max(0, int(output_frame_end if output_frame_end is not None else plan.total_frames))
     if images_out and hasattr(images_out[0], "shape"):
         end = max(end, int(images_out[0].shape[0]))
-    extracted = extract_timeline_audio(timeline, 0, end, fps) if end > 0 else None
+    extracted = (
+        extract_timeline_audio(
+            timeline,
+            0,
+            end,
+            fps,
+            audio_cache=_execution_audio_cache(plan),
+        )
+        if end > 0
+        else None
+    )
     if mode == AUDIO_MODE_SOURCE and not _audio_has_samples(extracted):
         hint = diagnose_source_audio_failure(timeline, 0, end, fps)
         # Soft fallback after a successful video run: silent only (no model audio).

--- a/director/executor_core.py
+++ b/director/executor_core.py
@@ -264,6 +264,35 @@ def _ref_video_audios_to_dict(items) -> dict | None:
     return out or None
 
 
+def _release_segment_file_ref_audios(plan: DirectorPlan, seg) -> None:
+    """Drop decoded per-segment file PCM; keep execution-shared/global slots."""
+    shared_ids = {id(item) for item in (getattr(plan, "global_ref_audios", None) or [])}
+    for item in getattr(seg, "ref_audios", None) or []:
+        if id(item) in shared_ids:
+            continue
+        if getattr(item, "audio_path", ""):
+            item.audio = None
+
+
+def _prune_continuity_working_set(
+    next_segment_index: int,
+    av_latents: dict[int, dict],
+    refine_passes: dict[int, list[tuple[str, torch.Tensor]]],
+) -> None:
+    """Keep only the direct predecessor needed by the next segment.
+
+    Final/pre-refine frames and export audio live in separate collections and
+    are intentionally untouched.  A missing direct predecessor is loaded from
+    the existing disk cache by the continuity path.
+    """
+    current = int(next_segment_index)
+    keep = current - 1
+    for working_set in (av_latents, refine_passes):
+        for index in tuple(working_set):
+            if int(index) < current and int(index) != keep:
+                working_set.pop(index, None)
+
+
 def execute_director_plan_core(
     plan: DirectorPlan,
     *,
@@ -1201,12 +1230,23 @@ def execute_director_plan_core(
         return chunk, audio_dict, pre_chunk
 
     for seg in all_segments:
+        # AV latent and decoded refine-pass clips are a rolling continuity
+        # working set, not final outputs.  At the start of segment N, only N-1
+        # can still be consumed; older entries have already been persisted.
+        _prune_continuity_working_set(
+            seg.index,
+            completed_av_latents,
+            completed_refine_passes,
+        )
         if seg.index in run_indices:
             if clear_vram_between_segments and segment_outputs:
                 cleanup_segment_vram(enabled=True)
-            chunk, audio_dict, pre_chunk = _run_one_segment(
-                seg, progress_index=progress_pos[seg.index]
-            )
+            try:
+                chunk, audio_dict, pre_chunk = _run_one_segment(
+                    seg, progress_index=progress_pos[seg.index]
+                )
+            finally:
+                _release_segment_file_ref_audios(plan, seg)
             segment_outputs.append(chunk)
             segment_pre_refine.append(pre_chunk)
             segment_audios.append(audio_dict or {})

--- a/director/external_groups.py
+++ b/director/external_groups.py
@@ -629,4 +629,5 @@ def build_plan_from_external_groups(
         run_indices=run_indices,
         continuity_enabled=continuity_enabled,
         continuity_overlap_frames=continuity_overlap,
+        global_ref_audios=list(common_audios_raw) if family == "r2v" else [],
     )

--- a/director/gen_timeline.py
+++ b/director/gen_timeline.py
@@ -295,6 +295,13 @@ def build_gen_director_plan(
         if global_block.get("commonEnabled") is not None
         else global_block.get("common_enabled")
     )
+    shared_ref_audios = (
+        _load_ref_audios(
+            global_block.get("refAudios") or global_block.get("ref_audios") or []
+        )
+        if edit_mode == "global" or common_enabled
+        else []
+    )
 
     output_block = timeline.get("output") or {}
     gen_block = timeline.get("gen") or {}
@@ -415,7 +422,7 @@ def build_gen_director_plan(
         if edit_mode == "global":
             seg_ref_audios = segment_ref_audios_for_context(
                 seg_task_key,
-                _load_ref_audios(global_block.get("refAudios") or global_block.get("ref_audios") or []),
+                list(shared_ref_audios),
             )
         else:
             local_audios = segment_ref_audios_for_context(
@@ -425,9 +432,7 @@ def build_gen_director_plan(
             if seg_task_key == "r2v" and common_enabled:
                 common_audios = segment_ref_audios_for_context(
                     seg_task_key,
-                    _load_ref_audios(
-                        global_block.get("refAudios") or global_block.get("ref_audios") or []
-                    ),
+                    list(shared_ref_audios),
                 )
                 seg_ref_audios = merge_indexed_refs(common_audios, local_audios)
             else:
@@ -539,4 +544,5 @@ def build_gen_director_plan(
         run_indices=_parse_run_selection(timeline, len(segments)),
         continuity_enabled=continuity_enabled,
         continuity_overlap_frames=continuity_overlap,
+        global_ref_audios=shared_ref_audios,
     )

--- a/director/plan.py
+++ b/director/plan.py
@@ -125,8 +125,9 @@ class SegmentRefAudio:
     """Standalone reference audio for MiniMax ``<Audio N>`` (index 0-based)."""
 
     index: int
-    audio: dict  # ComfyUI AUDIO: {waveform, sample_rate}
+    audio: dict | None  # ComfyUI AUDIO: {waveform, sample_rate}; lazy for uploaded files
     audio_file: str = ""
+    audio_path: str = ""  # absolute input path; runtime-only, excluded from cache identity
 
 
 @dataclass
@@ -222,6 +223,9 @@ class DirectorPlan:
     continuity_enabled: bool = False
     continuity_overlap_frames: int = 0
     global_ref_audios: list[SegmentRefAudio] = field(default_factory=list)
+    # Full source-video PCM reused only during this Director execution.  The
+    # plan is not a node output, so the cache dies with the current run.
+    audio_decode_cache: dict[str, dict[str, Any]] = field(default_factory=dict, repr=False)
     refine: dict | None = None
     # Sampling knobs stamped at execute time (first-pass cache fingerprint).
     sample_seed: int = 0
@@ -339,8 +343,8 @@ def _load_refs(ref_list: list[dict]) -> list[SegmentRef]:
     return sorted(refs, key=lambda r: r.index)
 
 
-def load_reference_audio_item(item: dict) -> dict | None:
-    """Load one timeline refAudios entry into a ComfyUI AUDIO dict."""
+def _reference_audio_file(item: dict) -> tuple[str, str]:
+    """Return (timeline-relative identity, absolute input path)."""
     rel = str(
         item.get("audioFile")
         or item.get("audio_file")
@@ -349,11 +353,19 @@ def load_reference_audio_item(item: dict) -> dict | None:
         or ""
     ).replace("\\", "/").strip()
     if not rel:
-        return None
+        return "", ""
     sub = str(item.get("subfolder") or "").replace("\\", "/").strip().strip("/")
     if sub and not rel.startswith(sub + "/"):
         rel = f"{sub}/{rel}"
     file_path = os.path.join(folder_paths.get_input_directory(), rel.replace("/", os.sep))
+    return rel, file_path
+
+
+def load_reference_audio_item(item: dict) -> dict | None:
+    """Load one timeline refAudios entry into a ComfyUI AUDIO dict."""
+    _rel, file_path = _reference_audio_file(item)
+    if not file_path:
+        return None
     if not os.path.isfile(file_path):
         log.warning("Reference audio missing: %s", file_path)
         return None
@@ -364,6 +376,7 @@ def load_reference_audio_item(item: dict) -> dict | None:
 
 
 def _load_ref_audios(audio_list: list[dict]) -> list[SegmentRefAudio]:
+    """Build lazy file-backed reference slots without decoding PCM up front."""
     out: list[SegmentRefAudio] = []
     for item in audio_list or []:
         if not isinstance(item, dict):
@@ -371,11 +384,20 @@ def _load_ref_audios(audio_list: list[dict]) -> list[SegmentRefAudio]:
         index = int(item.get("index", item.get("slot", len(out))))
         if index < 0 or index >= MAX_REFERENCE_AUDIOS:
             continue
-        audio = load_reference_audio_item(item)
-        if audio is None:
+        rel, file_path = _reference_audio_file(item)
+        if not file_path:
             continue
-        rel = str(item.get("audioFile") or item.get("audio_file") or item.get("fileName") or "").strip()
-        out.append(SegmentRefAudio(index=index, audio=audio, audio_file=rel))
+        if not os.path.isfile(file_path):
+            log.warning("Reference audio missing: %s", file_path)
+            continue
+        out.append(
+            SegmentRefAudio(
+                index=index,
+                audio=None,
+                audio_file=rel,
+                audio_path=file_path,
+            )
+        )
     return sorted(out, key=lambda a: a.index)
 
 
@@ -387,7 +409,17 @@ def segment_ref_audios_for_context(task_key: str, audios: list[SegmentRefAudio])
 
 
 def ref_audios_to_dict(audios: list[SegmentRefAudio]) -> dict | None:
-    return ref_audios_dict([(a.index, a.audio) for a in audios])
+    items: list[tuple[int, dict]] = []
+    for item in audios:
+        audio = item.audio
+        if audio is None and item.audio_path:
+            audio = load_reference_audio(item.audio_path)
+            item.audio = audio
+            if audio is None:
+                log.warning("Failed to decode reference audio: %s", item.audio_path)
+        if isinstance(audio, dict) and audio.get("waveform") is not None:
+            items.append((item.index, audio))
+    return ref_audios_dict(items)
 
 
 def _ref_video_entry_has_file(item: dict | None) -> bool:

--- a/lib/audio_io.py
+++ b/lib/audio_io.py
@@ -42,7 +42,6 @@ log = logging.getLogger("ComfyUI-MiniMaxH3-Director.audio")
 
 _ENCODE_ARGS = ("utf-8", "backslashreplace")
 
-_FULL_AUDIO_CACHE: dict[str, dict[str, Any]] = {}
 _OPENCV_FPS_CACHE: dict[str, float] = {}
 # path -> (video_pts0, audio_start, frame_dur)
 _AV_TIMING_CACHE: dict[str, tuple[float, float, float]] = {}
@@ -329,10 +328,23 @@ def load_reference_audio(path: str) -> dict[str, Any] | None:
     return _load_full_audio(path)
 
 
-def _load_full_audio(path: str) -> dict[str, Any] | None:
-    cached = _FULL_AUDIO_CACHE.get(path)
-    if cached is not None:
-        return cached
+def _load_full_audio(
+    path: str,
+    *,
+    cache: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
+    """Decode a complete audio stream, optionally reusing a caller-owned cache.
+
+    The module deliberately has no process-wide PCM cache.  Callers that need
+    to slice the same source repeatedly during one Director execution may pass
+    an execution-scoped ``cache``; uploaded/reference files otherwise behave
+    like images and videos and are decoded only while their current plan needs
+    them.
+    """
+    if cache is not None:
+        cached = cache.get(path)
+        if cached is not None:
+            return cached
     ffmpeg = _ffmpeg_bin()
     if not ffmpeg or not path or not os.path.isfile(path):
         return None
@@ -373,7 +385,8 @@ def _load_full_audio(path: str) -> dict[str, Any] | None:
         audio = audio[:usable]
     wave = audio.reshape((-1, out_ac)).transpose(0, 1).unsqueeze(0).contiguous()
     out = {"waveform": wave, "sample_rate": int(ar)}
-    _FULL_AUDIO_CACHE[path] = out
+    if cache is not None:
+        cache[path] = out
     return out
 
 
@@ -566,6 +579,8 @@ def extract_timeline_audio(
     logical_start: int,
     logical_end: int,
     frame_rate: float,
+    *,
+    audio_cache: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
     """Extract source audio for logical timeline range [start, end)."""
     spans = _timeline_audio_spans(timeline, logical_start, logical_end, frame_rate)
@@ -586,7 +601,7 @@ def extract_timeline_audio(
     sr = 44100
     fallback_seeks = 0
     for path, pcm_start, out_dur, native0, file_fps in spans:
-        full = _load_full_audio(path)
+        full = _load_full_audio(path, cache=audio_cache)
         if full is None:
             return None
         sr = int(full["sample_rate"] or sr)

--- a/nodes/director.py
+++ b/nodes/director.py
@@ -248,35 +248,43 @@ class MiniMaxH3Director:
             refine=refine,
         )
 
-        combined, segment_outputs, segment_audios, report, export_frame_counts, pre_combined, pre_segments, held_for_confirmation = (
-            execute_director_plan_core(
-                plan,
-                node_id=unique_id,
-                model=model,
-                vae=video_vae,
-                audio_vae=audio_vae,
-                clip=clip,
-                cfg=cfg,
-                seed=seed,
-                steps=steps,
-                sampler=sampler,
-                scheduler=scheduler,
-                sigmas=sigmas,
-                shift_video=shift_video,
-                shift_audio=shift_audio,
-                clear_vram_between_segments=clear_vram_between_segments,
+        try:
+            combined, segment_outputs, segment_audios, report, export_frame_counts, pre_combined, pre_segments, held_for_confirmation = (
+                execute_director_plan_core(
+                    plan,
+                    node_id=unique_id,
+                    model=model,
+                    vae=video_vae,
+                    audio_vae=audio_vae,
+                    clip=clip,
+                    cfg=cfg,
+                    seed=seed,
+                    steps=steps,
+                    sampler=sampler,
+                    scheduler=scheduler,
+                    sigmas=sigmas,
+                    shift_video=shift_video,
+                    shift_audio=shift_audio,
+                    clear_vram_between_segments=clear_vram_between_segments,
+                )
             )
-        )
 
-        return finalize_director_outputs(
-            plan,
-            combined,
-            segment_outputs,
-            report,
-            export_source_images=export_source_images,
-            segment_audios=segment_audios,
-            segment_frame_counts=export_frame_counts,
-            pre_refine_combined=pre_combined,
-            pre_refine_segments=pre_segments,
-            block_final_images=held_for_confirmation,
-        )
+            return finalize_director_outputs(
+                plan,
+                combined,
+                segment_outputs,
+                report,
+                export_source_images=export_source_images,
+                segment_audios=segment_audios,
+                segment_frame_counts=export_frame_counts,
+                pre_refine_combined=pre_combined,
+                pre_refine_segments=pre_segments,
+                block_final_images=held_for_confirmation,
+            )
+        finally:
+            # Full source/reference PCM is execution-scoped.  Clear explicitly
+            # on success and failure rather than waiting for cyclic GC.
+            plan.audio_decode_cache.clear()
+            for item in plan.global_ref_audios:
+                if getattr(item, "audio_path", ""):
+                    item.audio = None

--- a/tests/test_audio_cache_scope.py
+++ b/tests/test_audio_cache_scope.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMFY_ROOT = REPO_ROOT.parents[1]
+CUSTOM_NODES_ROOT = REPO_ROOT.parent
+sys.path.insert(0, str(COMFY_ROOT))
+sys.path.insert(0, str(CUSTOM_NODES_ROOT))
+
+from ComfyUI_MiniMaxH3_Director.director import plan
+from ComfyUI_MiniMaxH3_Director.director import executor_core
+from ComfyUI_MiniMaxH3_Director.lib import audio_io
+
+
+class FullAudioCacheScopeTests(unittest.TestCase):
+    def _decoded_pcm(self):
+        samples = np.asarray([0.0, 0.0, 0.25, -0.25], dtype=np.float32)
+        return SimpleNamespace(stdout=samples.tobytes(), stderr=b"")
+
+    def test_no_process_wide_pcm_cache(self):
+        self.assertFalse(hasattr(audio_io, "_FULL_AUDIO_CACHE"))
+        with (
+            patch.object(audio_io, "_ffmpeg_bin", return_value="ffmpeg"),
+            patch.object(audio_io, "_probe_audio_stream", return_value=(44100, 2)),
+            patch.object(audio_io.os.path, "isfile", return_value=True),
+            patch.object(audio_io.subprocess, "run", return_value=self._decoded_pcm()) as run,
+        ):
+            first = audio_io._load_full_audio("ref.wav")
+            second = audio_io._load_full_audio("ref.wav")
+
+        self.assertIsNot(first, second)
+        self.assertEqual(run.call_count, 2)
+
+    def test_caller_owned_cache_reuses_only_within_its_scope(self):
+        execution_cache = {}
+        with (
+            patch.object(audio_io, "_ffmpeg_bin", return_value="ffmpeg"),
+            patch.object(audio_io, "_probe_audio_stream", return_value=(44100, 2)),
+            patch.object(audio_io.os.path, "isfile", return_value=True),
+            patch.object(audio_io.subprocess, "run", return_value=self._decoded_pcm()) as run,
+        ):
+            first = audio_io._load_full_audio("source.mp4", cache=execution_cache)
+            second = audio_io._load_full_audio("source.mp4", cache=execution_cache)
+
+        self.assertIs(first, second)
+        self.assertEqual(run.call_count, 1)
+
+
+class ReferenceAudioLazyLoadTests(unittest.TestCase):
+    def test_file_reference_is_lazy_and_shared_object_decodes_once(self):
+        item = {"index": 1, "audioFile": "refs/voice.wav"}
+        waveform = __import__("torch").zeros(1, 2, 32)
+        decoded = {"waveform": waveform, "sample_rate": 44100}
+
+        with patch.object(plan.os.path, "isfile", return_value=True):
+            refs = plan._load_ref_audios([item])
+
+        self.assertEqual(len(refs), 1)
+        self.assertIsNone(refs[0].audio)
+        self.assertTrue(refs[0].audio_path.replace("\\", "/").endswith("refs/voice.wav"))
+
+        with patch.object(plan, "load_reference_audio", return_value=decoded) as load:
+            first = plan.ref_audios_to_dict(refs)
+            second = plan.ref_audios_to_dict(refs)
+
+        self.assertIs(first["ref_audio_1"], decoded)
+        self.assertIs(second["ref_audio_1"], decoded)
+        self.assertEqual(load.call_count, 1)
+
+    def test_segment_release_keeps_shared_and_graph_audio(self):
+        waveform = __import__("torch").zeros(1, 2, 32)
+        decoded = {"waveform": waveform, "sample_rate": 44100}
+        shared = plan.SegmentRefAudio(
+            index=0,
+            audio=decoded,
+            audio_file="global.wav",
+            audio_path="global.wav",
+        )
+        local = plan.SegmentRefAudio(
+            index=1,
+            audio=decoded,
+            audio_file="local.wav",
+            audio_path="local.wav",
+        )
+        graph_audio = plan.SegmentRefAudio(index=2, audio=decoded, audio_file="")
+        fake_plan = SimpleNamespace(global_ref_audios=[shared])
+        fake_segment = SimpleNamespace(ref_audios=[shared, local, graph_audio])
+
+        executor_core._release_segment_file_ref_audios(fake_plan, fake_segment)
+
+        self.assertIs(shared.audio, decoded)
+        self.assertIsNone(local.audio)
+        self.assertIs(graph_audio.audio, decoded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_continuity_working_set.py
+++ b/tests/test_continuity_working_set.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMFY_ROOT = REPO_ROOT.parents[1]
+CUSTOM_NODES_ROOT = REPO_ROOT.parent
+sys.path.insert(0, str(COMFY_ROOT))
+sys.path.insert(0, str(CUSTOM_NODES_ROOT))
+
+from ComfyUI_MiniMaxH3_Director.director.executor_core import (
+    _prune_continuity_working_set,
+)
+
+
+class ContinuityWorkingSetTests(unittest.TestCase):
+    def test_keeps_only_direct_predecessor_and_future_entries(self):
+        av_latents = {0: {"samples": "a"}, 1: {"samples": "b"}, 2: {"samples": "c"}}
+        refine_passes = {0: [("p1", "a")], 1: [("p1", "b")], 2: [("p1", "c")]}
+
+        _prune_continuity_working_set(2, av_latents, refine_passes)
+
+        self.assertEqual(set(av_latents), {1, 2})
+        self.assertEqual(set(refine_passes), {1, 2})
+
+    def test_missing_predecessor_does_not_keep_older_segment(self):
+        av_latents = {0: {"samples": "a"}, 1: {"samples": "b"}}
+        refine_passes = {0: [("p1", "a")], 1: [("p1", "b")]}
+
+        _prune_continuity_working_set(3, av_latents, refine_passes)
+
+        self.assertEqual(av_latents, {})
+        self.assertEqual(refine_passes, {})
+
+    def test_does_not_receive_or_modify_final_output_collections(self):
+        av_latents = {0: {"samples": "a"}, 1: {"samples": "b"}}
+        refine_passes = {0: [("p1", "a")], 1: [("p1", "b")]}
+        completed_outputs = {0: "final-a", 1: "final-b"}
+        completed_pre_refine = {0: "pre-a", 1: "pre-b"}
+        completed_audios = {0: "audio-a", 1: "audio-b"}
+
+        _prune_continuity_working_set(2, av_latents, refine_passes)
+
+        self.assertEqual(completed_outputs, {0: "final-a", 1: "final-b"})
+        self.assertEqual(completed_pre_refine, {0: "pre-a", 1: "pre-b"})
+        self.assertEqual(completed_audios, {0: "audio-a", 1: "audio-b"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/minimax_refine.js
+++ b/web/js/minimax_refine.js
@@ -420,8 +420,11 @@ function ensureFirstPassCacheUI(node) {
         refreshFirstPassCacheStatus(node);
     });
     const body = document.createElement("div");
-    body.style.cssText = "white-space:pre-wrap;word-break:break-word";
+    body.style.cssText = "white-space:pre-wrap;word-break:break-word;user-select:text;cursor:text";
     body.textContent = "等待检查…";
+    for (const eventName of ["pointerdown", "mousedown", "click"]) {
+        body.addEventListener(eventName, (event) => event.stopPropagation());
+    }
     header.append(title, refresh);
     root.append(header, body);
     const widget = node.addDOMWidget(CACHE_STATUS_WIDGET, "cache_status", root, {
@@ -599,6 +602,13 @@ app.registerExtension({
         };
     },
     nodeCreated(node) {
+        const cls = node?.comfyClass || node?.type || "";
+        if (DIRECTOR_CLASSES.has(cls)) {
+            node._mmxRefreshFirstPassCache = (delay = 0) => {
+                refreshCacheStatusForDirector(node, delay);
+            };
+            return;
+        }
         scheduleRefineRefresh(node);
     },
     loadedGraphNode(node) {

--- a/web/js/minimax_timeline.js
+++ b/web/js/minimax_timeline.js
@@ -10780,7 +10780,8 @@ class MiniMaxH3DirectorEditor {
 
     onGlobalField(field, value) {
         this.timeline.global = this.timeline.global || { refs: [] };
-        if (field === "taskType") {
+        const taskTypeChanged = field === "taskType";
+        if (taskTypeChanged) {
             const prevTaskKey = this._taskKey || resolveTaskKey(this.timeline.global?.taskType || "");
             this.timeline.global[field] = value;
             const prevMode = this._directorMode || "video";
@@ -10796,6 +10797,13 @@ class MiniMaxH3DirectorEditor {
         }
         if (field === "prompt" && this.globalPromptWidget) this.globalPromptWidget.value = value;
         this.scheduleTimelineSync();
+        if (taskTypeChanged) {
+            // The Director mode selector is a custom DOM control, so assigning the
+            // hidden task_type widget does not fire LiteGraph onWidgetChanged.
+            // Notify the linked Refine after the task workspace has been restored;
+            // its status request flushes timeline_data before comparing cache meta.
+            this.node?._mmxRefreshFirstPassCache?.(0);
+        }
         if (field === "prompt") this._schedulePromptRender();
         else this.scheduleRender();
     }


### PR DESCRIPTION
## 改动概述

- 移除进程级完整音频采样内存缓存，改为一次导演节点执行期间复用，并在执行结束后主动释放。
- 上传的参考音频改为按需解码；每段独立音频在该段完成后释放，全局共用音频只在当前执行期间复用。
- 段间连续性工作集只保留下一段需要的上一段音视频潜变量和二次采样画面，避免全部分段中间数据驻留到任务结束。
- 一采缓存状态文字支持选择复制；导演台切换文本生视频、图生视频、参考生视频和视频生视频等模式后，自动重新检查对应缓存。
- 已基于最新上游主分支完成整合，并保留上游新增的外接噪声表与生成性能优化。

## 验证

- 七项自动化测试全部通过。
- 后端源码编译检查通过。
- 前端脚本语法检查通过。
- 提交差异格式检查通过。