### PR TITLE
fix: 工作流重载后高级采样参数恢复为默认值

### DIFF
--- a/web/js/minimax_timeline.js
+++ b/web/js/minimax_timeline.js
@@ -451,6 +451,71 @@ function widgetByName(node, name) {
     return node.widgets?.find((w) => w.name === name);
 }
 
+function findDirectorWidget(node, name) {
+    const key = String(name || "");
+    const direct = widgetByName(node, key);
+    if (direct) return direct;
+    if (/control[_\s]?after[_\s]?generate/i.test(key)) {
+        for (const w of node?.widgets || []) {
+            for (const linked of w.linkedWidgets || []) {
+                const linkedName = String(linked?.name || linked?.label || "");
+                if (/control[_\s]?after[_\s]?generate/i.test(linkedName)) return linked;
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * ComfyUI applies widgets_values by index during configure(), before seed's
+ * control_after_generate linked combo may exist — shifting optional widgets
+ * (steps defaults back to 25). Re-apply saved values by name once widgets settle.
+ */
+function restoreDirectorWidgetsFromSaved(node, data) {
+    if (!node || !data) return false;
+
+    const named = data.widgets_values_named;
+    if (named && typeof named === "object") {
+        node._mmxRestoringSampleWidgets = true;
+        try {
+            for (const [name, value] of Object.entries(named)) {
+                if (name === "minimax_director_ui") continue;
+                if (value === undefined) continue;
+                const w = findDirectorWidget(node, name);
+                if (!w || w.serialize === false) continue;
+                w.value = value;
+            }
+        } finally {
+            node._mmxRestoringSampleWidgets = false;
+        }
+        return true;
+    }
+
+    const values = data.widgets_values;
+    if (!Array.isArray(values) || !values.length) return false;
+
+    node._mmxRestoringSampleWidgets = true;
+    try {
+        let idx = 0;
+        for (const w of node.widgets ?? []) {
+            if (w.serialize === false) continue;
+            if (idx >= values.length) break;
+            w.value = values[idx++];
+        }
+    } finally {
+        node._mmxRestoringSampleWidgets = false;
+    }
+    return true;
+}
+
+function applyDirectorConfigureRestore(node, data) {
+    if (!node) return;
+    finalizeDirectorWidgetOrder(node);
+    if (restoreDirectorWidgetsFromSaved(node, data)) {
+        snapshotDirectorSampleWidgets(node, { force: true, includeHidden: true });
+    }
+}
+
 const DIRECTOR_SAMPLE_VALUE_WIDGETS = [
     "steps",
     "sampler",
@@ -12013,7 +12078,7 @@ app.registerExtension({
         normalizeDirectorOutputs(node);
         pruneDirectorDomWidgets(node);
         if (!node._minimaxDomWidget) return;
-        finalizeDirectorWidgetOrder(node);
+        applyDirectorConfigureRestore(node, node._mmxSavedConfigureData);
         ensureDirectorDomWidgetWidth(node);
         bindDirectorDomWidgetSizing(node, node._minimaxDomWidget, () => node._minimaxEditor);
         const editor = initDirectorEditor(node);
@@ -12144,12 +12209,18 @@ app.registerExtension({
 
         const onConnectionsChange = nodeType.prototype.onConnectionsChange;
         nodeType.prototype.onConnectionsChange = function (...args) {
-            snapshotDirectorSampleWidgets(this);
+            if (!this._mmxPendingConfigureRestore) {
+                snapshotDirectorSampleWidgets(this);
+            }
             lockDirectorSampleSnap(this, 400);
             lockDirectorSigmasInput(this);
             const out = onConnectionsChange?.apply(this, args);
             this._minimaxEditor?.syncExternalGroupsTimeline?.();
-            settleDirectorSampleWidgets(this);
+            if (this._mmxPendingConfigureRestore) {
+                syncDirectorSchedulerWidgets(this, { restore: false });
+            } else {
+                settleDirectorSampleWidgets(this);
+            }
             return out;
         };
 
@@ -12176,12 +12247,18 @@ app.registerExtension({
         };
 
         const onConfigure = nodeType.prototype.onConfigure;
-        nodeType.prototype.onConfigure = function () {
+        nodeType.prototype.onConfigure = function (...args) {
             normalizeDirectorOutputs(this);
-            const out = onConfigure?.apply(this, arguments);
+            const saved = args[0];
+            if (saved) this._mmxSavedConfigureData = saved;
+            this._mmxPendingConfigureRestore = true;
+            const out = onConfigure?.apply(this, args);
+            const runRestore = () => applyDirectorConfigureRestore(this, this._mmxSavedConfigureData);
+            queueMicrotask(runRestore);
+            setTimeout(runRestore, 0);
             setTimeout(() => {
-                finalizeDirectorWidgetOrder(this);
-                snapshotDirectorSampleWidgets(this);
+                runRestore();
+                this._mmxPendingConfigureRestore = false;
                 syncDirectorSchedulerWidgets(this, { restore: false });
                 const ed = initDirectorEditor(this) || this._minimaxEditor;
                 if (!ed) return;


### PR DESCRIPTION
## Summary

- 修复工作流保存后重载时「高级采样」参数（`steps` / `sampler` / `scheduler` 等）被还原为默认值的问题（如 `steps` 从 8 变回 25）。
- 根因：ComfyUI `configure()` 按 `widgets_values` 数组下标恢复时，`seed` 的 `control_after_generate` 联动控件可能尚未挂载，导致 optional 控件整体错位。
- 在 widget 全部就绪后，优先按 `widgets_values_named` 按名称写回；无 named 字段的旧工作流则按最终 widget 顺序重放数组。
- 加载期间跳过基于错位值的 sample snapshot 恢复，避免 `settleDirectorSampleWidgets` 把错误默认值写回。

Fixes #85

## Test plan

- [ ] 打开含 `MiniMaxH3Director` 的工作流，将「高级采样」中 `steps` 改为 8（或其它非 25 值），保存
- [ ] 从工作流列表重新加载，确认 `steps` 仍为 8
- [ ] 刷新 ComfyUI 页面后再次加载，确认 `sampler` / `scheduler` 亦与保存一致
- [ ] 用无 `widgets_values_named` 的旧示例工作流加载，确认采样参数不被打乱
