### PR TITLE
fix: 「选择运行」重抽时 images_pre_refine 未勾选段优先用一采缓存填充

### DIFF
--- a/director/executor_core.py
+++ b/director/executor_core.py
@@ -1234,7 +1234,9 @@ def execute_director_plan_core(
             #「选择运行」re-roll previews merge all-first-pass frames instead of
             # mixing fresh 一采 with cached 二采. Falls back to the final render
             # when no first-pass cache exists (e.g. refine was never connected).
-            pre_fill = load_first_pass_frames_stale(node_id, seg, plan)
+            pre_fill = load_first_pass_frames_stale(
+                node_id, seg, plan, match_len=int(cached.shape[0])
+            )
             completed_pre_refine[seg.index] = (
                 pre_fill if pre_fill is not None else cached
             )

--- a/director/executor_core.py
+++ b/director/executor_core.py
@@ -59,6 +59,7 @@ from .h3_motion_context import (
 )
 from .segment_cache import (
     load_first_pass_cache,
+    load_first_pass_frames_stale,
     load_segment_audio,
     load_segment_av_latent,
     load_segment_cache,
@@ -1229,7 +1230,14 @@ def execute_director_plan_core(
         if cached is not None:
             cached = cached.float()
             completed_outputs[seg.index] = cached
-            completed_pre_refine[seg.index] = cached
+            # images_pre_refine fill prefers the first-pass render (.pre.pt) so
+            #「选择运行」re-roll previews merge all-first-pass frames instead of
+            # mixing fresh 一采 with cached 二采. Falls back to the final render
+            # when no first-pass cache exists (e.g. refine was never connected).
+            pre_fill = load_first_pass_frames_stale(node_id, seg, plan)
+            completed_pre_refine[seg.index] = (
+                pre_fill if pre_fill is not None else cached
+            )
             cached_audio = load_segment_audio(
                 node_id, seg, plan, allow_stale=used_stale
             )
@@ -1253,7 +1261,7 @@ def execute_director_plan_core(
                 f"({cached.shape[0]} frames{audio_note}{stale_note})"
             )
             output_chunks.append(cached)
-            output_pre_chunks.append(cached)
+            output_pre_chunks.append(completed_pre_refine[seg.index])
             output_segments.append(seg)
             continue
 

--- a/director/segment_cache.py
+++ b/director/segment_cache.py
@@ -594,6 +594,43 @@ def save_first_pass_cache(
             _safe_unlink(stray)
 
 
+def load_first_pass_frames_stale(
+    node_id: str | None,
+    seg: SegmentPlan,
+    plan: DirectorPlan,
+) -> torch.Tensor | None:
+    """Load ``.pre.pt`` frames for unselected-segment pre-refine fill.
+
+    Stale-tolerant counterpart of :func:`load_first_pass_cache`: fingerprint
+    drift (different seed, sampling-knob churn) does NOT invalidate the fill,
+    so「选择运行」re-roll previews merge all-first-pass frames instead of
+    mixing a fresh first pass with cached refined renders. A different source
+    video still rejects (same rule as the final-cache fill). Never raises.
+    """
+    if not node_id:
+        return None
+    root = _cache_root(node_id)
+    if root is None:
+        return None
+    idx = seg.index
+    frames_path = root / f"seg_{idx:04d}.pre.pt"
+    meta_path = root / f"seg_{idx:04d}.pre.meta.json"
+    if not frames_path.is_file():
+        return None
+    try:
+        if meta_path.is_file():
+            stored = json.loads(meta_path.read_text(encoding="utf-8"))
+            expected = first_pass_cache_fingerprint(seg, plan)
+            if _reject_source_stale(stored, expected, seg_index=idx, quiet=True):
+                return None
+        loaded = torch.load(frames_path, map_location="cpu", weights_only=True)
+        if isinstance(loaded, torch.Tensor) and loaded.numel() > 0:
+            return _frames_from_disk(loaded)
+    except Exception as exc:
+        log.debug("Segment %d first-pass stale frames skipped: %s", idx + 1, exc)
+    return None
+
+
 def load_first_pass_cache(
     node_id: str | None,
     seg: SegmentPlan,

--- a/director/segment_cache.py
+++ b/director/segment_cache.py
@@ -18,7 +18,7 @@ import torch
 
 import folder_paths
 
-from .h3_motion_context import CONTINUITY_PIPELINE_ID
+from .h3_motion_context import CONTINUITY_PIPELINE_ID, trim_context_prefix, trim_export_tail
 from .plan import DirectorPlan, SegmentPlan, resolve_ref_image_size
 
 log = logging.getLogger("ComfyUI-MiniMaxH3-Director.director.cache")
@@ -594,10 +594,38 @@ def save_first_pass_cache(
             _safe_unlink(stray)
 
 
+def _trim_stale_first_pass_frames(
+    frames: torch.Tensor,
+    *,
+    plan: DirectorPlan,
+    handoff: dict[str, Any] | None,
+    match_len: int | None,
+) -> torch.Tensor | None:
+    """Match in-memory first-pass export: drop context prefix, then crop length."""
+    fps = float(getattr(plan, "frame_rate", 24) or 24)
+    trim_frames = int((handoff or {}).get("trim_frames") or 0)
+    export_len = int((handoff or {}).get("export_frames") or 0)
+    if trim_frames > 0:
+        if int(frames.shape[0]) <= trim_frames:
+            return None
+        frames, _ = trim_context_prefix(
+            frames, None, trim_frames, fps=fps, match_tail=True
+        )
+    if export_len > 0 and int(frames.shape[0]) > export_len:
+        frames = frames[:export_len]
+    want = int(match_len or 0)
+    extra = int(frames.shape[0]) - want if want > 0 else 0
+    if extra > 0:
+        frames, _ = trim_export_tail(frames, None, extra, fps=fps)
+    return frames
+
+
 def load_first_pass_frames_stale(
     node_id: str | None,
     seg: SegmentPlan,
     plan: DirectorPlan,
+    *,
+    match_len: int | None = None,
 ) -> torch.Tensor | None:
     """Load ``.pre.pt`` frames for unselected-segment pre-refine fill.
 
@@ -606,6 +634,10 @@ def load_first_pass_frames_stale(
     so「选择运行」re-roll previews merge all-first-pass frames instead of
     mixing a fresh first pass with cached refined renders. A different source
     video still rejects (same rule as the final-cache fill). Never raises.
+
+    Disk ``.pre.pt`` is written before export trim; this reapplies
+    ``.pre.handoff.json`` (context prefix + export length) and optionally
+    matches the final-cache frame count after later phase-align tail trims.
     """
     if not node_id:
         return None
@@ -615,6 +647,7 @@ def load_first_pass_frames_stale(
     idx = seg.index
     frames_path = root / f"seg_{idx:04d}.pre.pt"
     meta_path = root / f"seg_{idx:04d}.pre.meta.json"
+    handoff_path = root / f"seg_{idx:04d}.pre.handoff.json"
     if not frames_path.is_file():
         return None
     try:
@@ -624,8 +657,22 @@ def load_first_pass_frames_stale(
             if _reject_source_stale(stored, expected, seg_index=idx, quiet=True):
                 return None
         loaded = torch.load(frames_path, map_location="cpu", weights_only=True)
-        if isinstance(loaded, torch.Tensor) and loaded.numel() > 0:
-            return _frames_from_disk(loaded)
+        if not isinstance(loaded, torch.Tensor) or loaded.numel() <= 0:
+            return None
+        frames = _frames_from_disk(loaded)
+        if frames is None:
+            return None
+        handoff = None
+        if handoff_path.is_file():
+            try:
+                data = json.loads(handoff_path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    handoff = data
+            except Exception:
+                handoff = None
+        return _trim_stale_first_pass_frames(
+            frames, plan=plan, handoff=handoff, match_len=match_len
+        )
     except Exception as exc:
         log.debug("Segment %d first-pass stale frames skipped: %s", idx + 1, exc)
     return None


### PR DESCRIPTION
## 使用场景

整部视频已经完成**一采 + 二采**（Refine 已出成片）。之后想**重新生成其中某一个片段**（换 seed 抽卡 / 改提示词），于是开启「选择运行」只勾选该段重跑。

由于重新生成的只是一采，此时合并预览应**先合并全程一采视频**：

- 勾选段 = 新一采
- 未勾选段 = `.pre.pt` 一采缓存

比稿确认满意后，用**同一 seed** 再次 Queue，命中一采缓存只跑二采，最终 `images` 仍合并出全二采成片。这才是「先出一采确认、再二采成片」的完整流程。

## 修复前的问题

重抽后 `images_pre_refine` 合并的是 **新一采（重抽段）+ 二采缓存（未勾选段）**，两种画质混搭，无法直接比稿。

原因：

- 未勾选段填充走 `load_segment_cache()`，读的是 `seg_XXXX.pt`（最后一次完整渲染 = 二采成片）
- `completed_pre_refine[idx]` / `output_pre_chunks` 直接复用该 tensor（`executor_core.py` 未勾选段填充块）
- 而 `.pre.pt`（一采帧）在 Refine 接线时本来每次采样都会写（`if will_refine and not skip_first_sample: save_first_pass_cache(...)`），数据已齐备，只是填充逻辑没有使用

## 修复方式

1. `segment_cache.py` 新增 `load_first_pass_frames_stale()`：
   - stale 容忍的一采帧读取（seed / 采样参数变化不失效；仅来源视频变化时拒绝，与最终缓存填充规则一致）
   - 任何异常返回 `None`，不影响主流程
2. `executor_core.py` 未勾选段填充处：`completed_pre_refine[idx]` / `output_pre_chunks` 优先用一采帧，无 `.pre.pt` 时回退现行行为（最终渲染）

## 修复后行为

| 输出口 | 「选择运行」重抽时 |
| --- | --- |
| `images_pre_refine` | 新一采（勾选段）+ 一采缓存（未勾选段）= **全程一采预览** |
| `images` | 不变：二采（勾选段）+ 二采缓存（未勾选段）= 全程二采成片 |

## 影响范围

- 仅影响「选择运行」未勾选段在 `images_pre_refine` 输出口的填充来源
- 不改动：采样、二采逻辑、主 `images` 输出、缓存写入、段间引导、音频
- 未接 Refine 的工作流不受影响（无 `.pre.pt`，回退原行为）

## 测试

- `python -m py_compile` 通过
- 本机实测场景：4 段 r2v + Refine（二采_加速工作流），全片一采+二采后，「选择运行」勾选 1 段换 seed 重抽，`images_pre_refine` 为全程一采，`images` 为全程二采
