### PR TITLE
fix: r2v/v2v/rv2v 报错 TypeError: unsupported operand type(s) for //: 'str' and 'int'（#111）

### DIFF
--- a/nodes/conditioning.py
+++ b/nodes/conditioning.py
@@ -132,28 +132,34 @@ def run_minimax_conditioning(
     if use_reference:
         if audio_vae is None:
             raise ValueError("MiniMax H3 r2v/v2v/rv2v / reference conditioning requires audio_vae.")
+        # Keyword args only: official execute() has reordered vae/audio_vae to
+        # trailing optional params across ComfyUI versions before (e.g. moving
+        # them after ref_image_size). Positional args silently misalign and
+        # send strings into int slots (`TypeError: ... for //: 'str' and 'int'`
+        # inside _empty_av_latent) instead of raising a clear error.
         out = MiniMaxH3ReferenceToVideo.execute(
-            clip,
-            vae,
-            audio_vae,
-            prompt,
-            width,
-            height,
-            length,
-            ref_image_size,
+            clip=clip,
+            prompt=prompt,
+            width=width,
+            height=height,
+            length=length,
+            ref_image_size=ref_image_size,
+            vae=vae,
+            audio_vae=audio_vae,
             ref_images=ref_images,
             ref_videos=ref_videos,
             ref_video_audios=ref_video_audios,
             ref_audios=ref_audios,
         )
     else:
+        # Keyword args for the same reason as MiniMaxH3ReferenceToVideo above.
         out = MiniMaxH3ImageToVideo.execute(
-            clip,
-            vae,
-            prompt,
-            width,
-            height,
-            length,
+            clip=clip,
+            vae=vae,
+            prompt=prompt,
+            width=width,
+            height=height,
+            length=length,
             first_frame=first_frame,
             last_frame=last_frame,
         )


### PR DESCRIPTION
## 这个 PR 解决什么问题

修复 #111：r2v / v2v / rv2v 任务报错 `TypeError: unsupported operand type(s) for //: 'str' and 'int'`，两位使用者（Copipi、iamverygood）都在最新 ComfyUI 上复现，完整堆栈指向 `comfy_extras/nodes_minimax_h3.py` 的 `_empty_av_latent()`：

```
File "comfy_extras/nodes_minimax_h3.py", line 85, in _empty_av_latent
    video = torch.zeros([batch_size, 24, latent_t, height // 16, width // 16], ...)
TypeError: unsupported operand type(s) for //: 'str' and 'int'
```

## 根因

`nodes/conditioning.py` 调用官方 `MiniMaxH3ReferenceToVideo.execute()` 时用的是位置参数：

```python
out = MiniMaxH3ReferenceToVideo.execute(
    clip, vae, audio_vae, prompt, width, height, length, ref_image_size, ...
)
```

但官方节点当前的签名是：

```python
def execute(cls, clip, prompt, width, height, length, ref_image_size="match",
            vae=None, audio_vae=None, ref_images=None, ...)
```

`vae` / `audio_vae` 已经被挪到 `ref_image_size` 之后、变成尾部可选关键字参数。导演台这边还在按旧顺序传位置参数，于是每个参数整体错位一格：

| 导演台传的位置参数 | 实际落进官方哪个参数 |
| --- | --- |
| `vae`（VAE 对象） | → `prompt` |
| `audio_vae`（VAE 对象） | → `width` |
| **`prompt`（字符串）** | → **`height`** ← 就是这里炸的 |
| `width` | → `length` |
| `height` | → `ref_image_size` |
| `length` | → `vae` |

`prompt` 这个字符串落进官方的 `height` 参数，传进 `_empty_av_latent()` 算 `height // 16` 时对字符串做除法，直接抛错。

`MiniMaxH3ImageToVideo.execute()` 的官方签名（`clip, vae, prompt, width, height, length, first_frame=None, last_frame=None`）里 `vae` 还在原本位置，这条路径（t2v / i2v / fl2v）不受影响。

## 修法

两处调用都改成关键字参数，不再依赖位置顺序：

```python
out = MiniMaxH3ReferenceToVideo.execute(
    clip=clip,
    prompt=prompt,
    width=width,
    height=height,
    length=length,
    ref_image_size=ref_image_size,
    vae=vae,
    audio_vae=audio_vae,
    ref_images=ref_images,
    ref_videos=ref_videos,
    ref_video_audios=ref_video_audios,
    ref_audios=ref_audios,
)
```

`MiniMaxH3ImageToVideo.execute()` 那条路径参数顺序本身没变、目前不受影响，但一并改成关键字参数，避免下次官方再调整签名时重蹈覆辙——关键字参数只要参数名不变，就不会因为顺序调整而静默错位。

## 影响范围

- ✅ 修复：r2v / v2v / rv2v（凡是会走 `MiniMaxH3ReferenceToVideo` 的任务类型）
- ❌ 不受影响：t2v / i2v / fl2v（走 `MiniMaxH3ImageToVideo`，官方签名顺序没变）

## 测试

- `py_compile nodes/conditioning.py` 通过
- 对照官方 `comfy_extras/nodes_minimax_h3.py` 当前的 `MiniMaxH3ReferenceToVideo.execute()` / `MiniMaxH3ImageToVideo.execute()` 签名逐个参数核对，确认关键字全部对得上

🤖 Generated with [Claude Code](https://claude.com/claude-code)
