### PR TITLE
fix: 段间引导保留模型生成的完整尾部，修复句尾读音/收音被吞音

### DIFF
--- a/director/executor_core.py
+++ b/director/executor_core.py
@@ -962,7 +962,8 @@ def execute_director_plan_core(
                 f"from seg #{seg.index} "
                 f"({'AV latent' if prev_av is not None else 'pixels'}"
                 f"{', +audio' if pin_audio else ', video-only'}); "
-                f"sample={sample_len}f → export {num_frames}f"
+                f"sample={sample_len}f → export {sample_len - trim_frames}f "
+                f"(UI {num_frames}f, kept full tail)"
                 + (
                     f"; trimmed prev export -{trimmed_prev_export}f (phase pin)"
                     if trimmed_prev_export
@@ -1075,7 +1076,16 @@ def execute_director_plan_core(
         if first_pass_gpu is not None and upscale_frames is None:
             del first_pass_gpu
             first_pass_gpu = None
-        export_len = int(num_frames) if trim_frames > 0 else int(target_len)
+        # Motion context: sample runs longer than the UI segment by the locked
+        # ctx head + grid remainder. After trimming the ctx head, keep the full
+        # model-generated free region (sample-trim) instead of cropping back to
+        # num_frames — cropping hard-cut the ~0.5s tail (sentence-final 2-3
+        # syllables / fade-out), and the next segment's phase-aligned pin would
+        # trim this segment's tail again. Non-continuity segments (trim=0) still
+        # export at the UI length target_len.
+        export_len = (
+            int(sample_len) - int(trim_frames) if trim_frames > 0 else int(target_len)
+        )
         if will_refine and not skip_first_sample:
             save_first_pass_cache(
                 node_id,
@@ -1180,10 +1190,14 @@ def execute_director_plan_core(
         decoded, audio_dict = _decode_av_latent(
             samples, vae, audio_vae, decode_audio=decode_audio,
         )
-        # Keep exactly the UI segment length. With motion context, sample is
-        # longer (visible+ctx, 17k+5 aligned); after trim, crop to num_frames.
-        # Next segment must pin at export end (trim+export), not sample end.
-        export_len = int(num_frames) if trim_frames > 0 else int(target_len)
+        # Keep the full model-generated free region after the ctx head trim
+        # (sample-trim) for motion-context segments — cropping back to num_frames
+        # dropped the ~0.5s sentence tail and made the next pin trim this segment.
+        # Non-continuity segments (trim=0) still crop to the UI length target_len.
+        # Next segment pins at export end (trim+export == sample end → grid-aligned).
+        export_len = (
+            int(sample_len) - int(trim_frames) if trim_frames > 0 else int(target_len)
+        )
         decoded, audio_dict = _trim_decoded_to_export(
             decoded,
             audio_dict,

--- a/director/h3_motion_context.py
+++ b/director/h3_motion_context.py
@@ -32,9 +32,12 @@ DEFAULT_CONTEXT_FRAMES = 22
 VIDEO_RUN_GRID = (124, 107, 90, 73, 56, 39, 22, 5, 1)
 
 CONTINUITY_TASK_KEYS = frozenset({"t2v", "i2v", "fl2v", "r2v", "v2v", "rv2v"})
-# v8: v7 + export audio cache + fps in fingerprint + trim hydrate on partial re-run.
+# v9: export the full free region (sample-trim) instead of cropping back to UI
+# visible — cropping cut the ~0.5s sentence tail / audio fade-out and made every
+# interior pin phase-trim the previous export. Bumps the cache fingerprint: old
+# v8 continuity caches have the shorter (cropped) length and must regenerate.
 # Single source of truth — imported by segment_cache.segment_cache_fingerprint.
-CONTINUITY_PIPELINE_ID = "minimax_h3_motion_context_v8"
+CONTINUITY_PIPELINE_ID = "minimax_h3_motion_context_v9"
 # Example workflow tested value (NikoDemon80): audio_context_length=24 with video=22.
 DEFAULT_AUDIO_CONTEXT_FRAMES = 24
 
@@ -576,19 +579,24 @@ def trim_export_tail(
 def generation_frame_budget(visible_frames: int, context_frames: int) -> tuple[int, int]:
     """Return ``(sample_length, trim_frames)`` for Director continuity.
 
-    Director contract: UI segment duration == exported frames.
+    Export contract (v9): the exported segment is the full model-generated
+    free region ``sample_length - trim_frames`` — NOT the UI ``visible`` count.
 
     Standalone Motion Context sets ``length`` to the sample and delivers
-    ``length - context`` (shorter than the UI seconds). That produced the
-    27s-vs-30s result. Here we instead:
+    ``length - context``. We do the same but keep the *entire* free region
+    instead of cropping back to ``visible``:
 
-    1. ``sample = align(visible + context)`` so the pin fits in the head
-    2. Trim ``context`` frames after decode
-    3. Keep exactly ``visible`` frames for export
-    4. Next pin uses ``context_end_frame = trim + visible`` (not the sample
-       absolute end, which includes align overshoot beyond the export)
-    5. If phase-align places the pin a few frames before that export end,
-       drop those frames from the previous export before concat (v7)
+    1. ``sample = align(visible + context)`` so the pin fits in the head.
+       Because ``visible ≡ 5`` and ``context ≡ 5`` on the 17k+5 grid,
+       ``visible + context ≡ 10`` and align rounds up 12 → the free region
+       ``sample - context`` is ``visible + 12`` (one grid remainder longer).
+    2. Trim ``context`` frames after decode (the pinned head is discarded).
+    3. Export the whole free region ``sample - context``. Cropping it back to
+       ``visible`` discarded ~12f (≈0.5s) at the tail — the sentence-final
+       2–3 syllables / audio fade-out got cut.
+    4. The next pin therefore ends at ``trim + export == sample``, which is
+       exactly on the 17k+5 grid → phase-aligned window reaches the latent
+       end with ``gap = 0``, so the previous export is no longer tail-trimmed.
     """
     from .frame_align import minimax_align_frame_count
 

--- a/nodes/director_common.py
+++ b/nodes/director_common.py
@@ -341,7 +341,16 @@ def _layout_image_batches(
         images_out = segment_outputs
         frame_count = sum(int(s.shape[0]) for s in segment_outputs)
         return images_out, frame_count
-    combined = pad_or_trim_frames(combined, plan.total_frames).cpu().float()
+    # Motion context: interior segments keep the full model-generated free
+    # region (grid remainder longer than the UI segment), so the combined clip
+    # is naturally longer than plan.total_frames. Do not crop back to the UI
+    # total here — that cuts the ending fade-out and desyncs from the audio
+    # concatenated at real segment lengths. Non-continuity mode keeps the old
+    # behavior (crop to the UI total).
+    if getattr(plan, "continuity_enabled", False):
+        combined = combined.cpu().float()
+    else:
+        combined = pad_or_trim_frames(combined, plan.total_frames).cpu().float()
     return [combined], int(combined.shape[0])
 
 


### PR DESCRIPTION
- generation_frame_budget: 导出段改为完整自由区 sample-trim，不再裁回 UI visible（裁回会丢尾部约0.5s、约12帧）
- executor_core: continuity 段 export_len 用 sample_len-trim_frames，非连续段仍按 UI 段长 target_len
- director_common: continuity 合并片不再裁回 total_frames，避免结尾收音被裁及与按实长拼接的音频错位
- 缓存指纹 v8→v9，旧的短缓存自动失效重算