### PR TITLE
fix: 修复参考音频音色丢失/错位（<Audio N> 标签与音频槽位严格对齐）

### DIFF
--- a/director/plan.py
+++ b/director/plan.py
@@ -125,9 +125,9 @@ class SegmentRefAudio:
     """Standalone reference audio for MiniMax ``<Audio N>`` (index 0-based)."""
 
     index: int
-    audio: dict | None = None  # ComfyUI AUDIO; lazy for uploaded files
+    audio: dict  # ComfyUI AUDIO: {waveform, sample_rate}; decoded eagerly at build
     audio_file: str = ""
-    audio_path: str = ""  # absolute input path; runtime-only, not a cache identity
+    audio_path: str = ""  # absolute input path (runtime-only; for cache fingerprint)
 
 
 @dataclass
@@ -223,7 +223,8 @@ class DirectorPlan:
     continuity_enabled: bool = False
     continuity_overlap_frames: int = 0
     global_ref_audios: list[SegmentRefAudio] = field(default_factory=list)
-    # Full source-video PCM reused only during this Director execution.
+    # Full source-video PCM, reused only during this one Director execution and
+    # freed when the run ends (replaces the old never-cleared process cache).
     audio_decode_cache: dict = field(default_factory=dict, repr=False)
     refine: dict | None = None
     # Sampling knobs stamped at execute time (first-pass cache fingerprint).
@@ -345,7 +346,7 @@ def _load_refs(ref_list: list[dict]) -> list[SegmentRef]:
 
 
 def _reference_audio_file(item: dict) -> tuple[str, str]:
-    """Return (timeline-relative identity, absolute input path)."""
+    """Return (timeline identity rel, absolute input path) for a refAudios entry."""
     rel = str(
         item.get("audioFile")
         or item.get("audio_file")
@@ -356,9 +357,10 @@ def _reference_audio_file(item: dict) -> tuple[str, str]:
     if not rel:
         return "", ""
     sub = str(item.get("subfolder") or "").replace("\\", "/").strip().strip("/")
-    if sub and not rel.startswith(sub + "/"):
-        rel = f"{sub}/{rel}"
-    file_path = os.path.join(folder_paths.get_input_directory(), rel.replace("/", os.sep))
+    located = rel
+    if sub and not located.startswith(sub + "/"):
+        located = f"{sub}/{located}"
+    file_path = os.path.join(folder_paths.get_input_directory(), located.replace("/", os.sep))
     return rel, file_path
 
 
@@ -377,7 +379,14 @@ def load_reference_audio_item(item: dict) -> dict | None:
 
 
 def _load_ref_audios(audio_list: list[dict]) -> list[SegmentRefAudio]:
-    """Build lazy file-backed reference slots without decoding PCM up front."""
+    """Eagerly decode uploaded reference audio at plan build.
+
+    Decoding up front (instead of lazily during the generation loop) guarantees
+    the ``<Audio N>`` PCM is in memory before conditioning, and keeps a slot only
+    when decode actually succeeded — so prompt ``<Audio N>`` tags always line up
+    with a populated ref_audio slot (no tag-to-empty-slot mismatch = no silent
+    timbre drop).
+    """
     out: list[SegmentRefAudio] = []
     for item in audio_list or []:
         if not isinstance(item, dict):
@@ -391,10 +400,14 @@ def _load_ref_audios(audio_list: list[dict]) -> list[SegmentRefAudio]:
         if not os.path.isfile(file_path):
             log.warning("Reference audio missing: %s", file_path)
             continue
+        audio = load_reference_audio(file_path)
+        if audio is None:
+            log.warning("Failed to decode reference audio: %s", file_path)
+            continue
         out.append(
             SegmentRefAudio(
                 index=index,
-                audio=None,
+                audio=audio,
                 audio_file=rel,
                 audio_path=file_path,
             )

--- a/director/segment_cache.py
+++ b/director/segment_cache.py
@@ -89,6 +89,26 @@ def _cache_root(node_id: str) -> Path | None:
         return None
 
 
+def _ref_audio_file_stamp(audio: Any, fallback_index: int) -> str:
+    """Fingerprint fragment for one reference audio.
+
+    Keying on the uploaded filename alone misses the case where the user keeps
+    the same slot/filename but replaces the audio content. Stamp the source
+    file's mtime+size so a content swap invalidates the first-pass cache.
+    """
+    index = getattr(audio, "index", fallback_index)
+    name = getattr(audio, "audio_file", "") or ""
+    path = getattr(audio, "audio_path", "") or ""
+    stamp = ""
+    if path:
+        try:
+            st = os.stat(path)
+            stamp = f"{int(st.st_mtime)}:{int(st.st_size)}"
+        except OSError:
+            stamp = ""
+    return f"aud{index}:{name}:{stamp}"
+
+
 def _segment_identity_fingerprint(seg: SegmentPlan, plan: DirectorPlan) -> dict[str, Any]:
     """Identity that affects first-pass sampling (no Refine settings)."""
     ref_files = sorted(
@@ -96,7 +116,7 @@ def _segment_identity_fingerprint(seg: SegmentPlan, plan: DirectorPlan) -> dict[
         for ref in seg.refs
     )
     ref_audio_files = sorted(
-        f"aud{getattr(a, 'index', i)}:{(getattr(a, 'audio_file', '') or '')}"
+        _ref_audio_file_stamp(a, i)
         for i, a in enumerate(getattr(seg, "ref_audios", None) or [])
     )
     ref_video_files = sorted(


### PR DESCRIPTION
参考音频改为在 plan 构建阶段立即解码（eager）：
- _load_ref_audios 构建时即调用 load_reference_audio，解码失败的条目直接 跳过、不占槽位；<Audio N> 提示标签与实际传给模型的音频都基于同一份 "仅含解码成功项"的 ref_audios 列表，严格一一对齐。
- 上游 lazy 方案运行时才解码：解码失败的条目 audio=None 却仍留在 ref_audios 中占槽，audio_idxs 仍把它计入 <Audio N> 标签，而 ref_audios_to_dict 因 audio 非 dict 跳过它 —— 标签数多于实际音频数、 标签与槽位错位，表现为音色静默丢失/串音。

首采缓存指纹加入参考音频文件的 mtime+size（segment_cache）：
- 上游仅按文件名做指纹，用户在同一槽位/同名替换音频内容后首采缓存不 失效、仍命中旧音色；现改为 stat 源文件 mtime+size，内容替换即失效。

与上游 e00b408 的关系（冲突说明）：
- 上游已独立实现"进程级缓存改为 plan 级 audio_decode_cache""运行结束在 finally 中 cache.clear() 并把 global_ref_audios 的 audio 置 None" "global_ref_audios 解码后共享传递""连续性工作集剪枝 _prune_continuity_working_set"等，本 PR 不重复这些改动 （executor_core.py / gen_timeline.py / nodes/director.py 相对上游净改动为 0）。
- 本 PR 相对上游的净差异仅两点：① 参考音频解码时机由 lazy 改为 eager， 解码失败不建槽，从根上消除 <Audio N> 标签/槽位错位；② 首采缓存指纹 增加参考音频 mtime+size。二者均为上游 lazy / 仅文件名方案未覆盖的音色问题。