### PR TITLE
fix: 修复分段导出最终视频仅1帧及分段mp4写出失败

### DIFF
--- a/director/executor_core.py
+++ b/director/executor_core.py
@@ -1342,7 +1342,11 @@ def execute_director_plan_core(
             completed_av_latents,
             completed_refine_passes,
         )
-        if export_segments_mode:
+        # Only a segment we actually sample consumes a predecessor pin and marks
+        # a real VRAM milestone. Skipped segments in a partial run-selection do
+        # neither, so they must not trigger a release — the earlier sampled clips
+        # are this run's deliverables and still feed the images output.
+        if export_segments_mode and seg.index in run_indices:
             # Older than the predecessor cannot be pinned anymore.
             for stale in tuple(completed_outputs):
                 if int(stale) < int(seg.index) - 1:

--- a/lib/video_export.py
+++ b/lib/video_export.py
@@ -154,13 +154,12 @@ def write_frames_to_mp4(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        assert proc.stdin is not None
-        try:
-            proc.stdin.write(rgb.tobytes())
-            proc.stdin.close()
-        except BrokenPipeError:
-            pass
-        stdout, stderr = proc.communicate()
+        # communicate(input=...) writes, flushes and closes stdin itself. Closing
+        # stdin by hand first makes CPython >=3.12 communicate() call flush() on
+        # the already-closed pipe and raise "flush of closed file". communicate()
+        # also tolerates ffmpeg exiting early (broken pipe) and still collects
+        # stderr, so the returncode check below reports the real encoder error.
+        stdout, stderr = proc.communicate(input=rgb.tobytes())
         if proc.returncode != 0 or not tmp_mp4.is_file() or tmp_mp4.stat().st_size <= 0:
             err = (stderr or b"").decode("utf-8", errors="replace").strip()
             raise RuntimeError(f"ffmpeg encode failed (code={proc.returncode}): {err or 'unknown'}")


### PR DESCRIPTION
- executor_core: 分段显存释放收窄为仅在实际采样段触发，「选择运行」跳过段不再把已采样片段误释放成1帧海报
- video_export: ffmpeg 改用 communicate(input=) 写 stdin，规避 Python 3.12 手动关闭 stdin 后 communicate() 再 flush 报 flush of closed file