### PR TITLE
feat: 增加Refine节点分块支持(enable_chunking)，优化8G显存体验

### DIFF
--- a/director/h3_latent_upscale.py
+++ b/director/h3_latent_upscale.py
@@ -189,9 +189,88 @@ class LatentResizer3D(nn.Module):
         self.norm_out = _normalization(channels)
         self.conv_out = nn.Conv3d(channels, in_channels, 3, padding=1)
 
-    def forward(self, x, scale: float, target_size: tuple[int, int, int]):
+    def _temporal_kernel(self) -> int:
+        """Temporal dwconv kernel size from weights (fallback 5). Used as chunk overlap."""
+        for block in list(self.in_blocks) + list(self.out_blocks):
+            if isinstance(block, TemporalConv):
+                return int(block.dwconv.weight.shape[2])
+        return 5
+
+    def forward(
+        self,
+        x,
+        scale: float,
+        target_size: tuple[int, int, int],
+        enable_chunking: bool = True,
+    ):
         if tuple(target_size) == tuple(x.shape[-3:]):
             return x
+
+        b, c, t = x.shape[0], x.shape[1], x.shape[2]
+        chunk = 24  # 有效帧数/块（与独立节点一致）
+        overlap = self._temporal_kernel()
+
+        if not enable_chunking or t <= chunk:
+            return self._forward_seg(x, scale, target_size)
+
+        log.info(
+            "H3 latent upscaler temporal chunking: T=%d chunks=%d overlap=%d",
+            t,
+            (t + chunk - 1) // chunk,
+            overlap,
+        )
+        size = (int(target_size[0]), int(target_size[1]), int(target_size[2]))
+
+        x_padded = F.pad(x, (0, 0, 0, 0, overlap, overlap), mode="replicate")
+
+        out_full = torch.zeros(b, c, t, size[-2], size[-1], device=x.device, dtype=x.dtype)
+        weight_full = torch.zeros(1, 1, t, 1, 1, device=x.device, dtype=x.dtype)
+
+        start = 0
+        while start < t:
+            seg_start = start
+            seg_end = min(t, start + chunk)
+
+            # 输出范围含重叠区，块间才能加权融合
+            out_start = max(0, seg_start - overlap)
+            out_end = min(t, seg_end + overlap)
+
+            # padded 张量上的切片（额外的上下文帧）
+            lo = max(0, out_start - overlap)
+            hi = min(t + 2 * overlap, out_end + overlap)
+
+            seg = x_padded[:, :, lo:hi]
+            seg_size = (hi - lo, size[-2], size[-1])
+            seg_out = self._forward_seg(seg, scale, seg_size)
+
+            s0 = (out_start + overlap) - lo
+            valid_out = seg_out[:, :, s0 : s0 + (out_end - out_start)]
+            n_valid = out_end - out_start
+
+            weight = torch.ones(n_valid, device=x.device, dtype=x.dtype)
+            # 前重叠区：权重 0→1 线性递增
+            if seg_start > out_start:
+                blend_len = seg_start - out_start
+                weight[:blend_len] = (
+                    torch.arange(1, blend_len + 1, device=x.device, dtype=x.dtype)
+                    / (blend_len + 1)
+                )
+            # 后重叠区：权重 1→0 线性递减
+            if out_end > seg_end:
+                blend_len = out_end - seg_end
+                weight[-blend_len:] = (
+                    torch.arange(blend_len, 0, -1, device=x.device, dtype=x.dtype)
+                    / (blend_len + 1)
+                )
+
+            out_full[:, :, out_start:out_end] += valid_out * weight.view(1, 1, n_valid, 1, 1)
+            weight_full[:, :, out_start:out_end] += weight.view(1, 1, n_valid, 1, 1)
+
+            start += chunk
+
+        return out_full / weight_full.clamp(min=1e-8)
+
+    def _forward_seg(self, x, scale: float, target_size: tuple[int, int, int]):
         scale_emb = torch.tensor(
             [float(scale) - 1.0], dtype=x.dtype, device=x.device
         ).unsqueeze(0)
@@ -335,6 +414,7 @@ def upscale_h3_video_latent(
     source_height: int,
     model_name: str = "",
     model=None,
+    enable_chunking: bool = True,
 ) -> dict:
     """Spatially upscale MiniMax H3 video latent to a pixel canvas (×16 VAE)."""
     if model is None and (not model_name or str(model_name).startswith("(")):
@@ -382,7 +462,12 @@ def upscale_h3_video_latent(
     x = (x - mean) / std
     try:
         with torch.no_grad():
-            out = model(x, scale=scale, target_size=(t_size, dst_h, dst_w))
+            out = model(
+                x,
+                scale=scale,
+                target_size=(t_size, dst_h, dst_w),
+                enable_chunking=enable_chunking,
+            )
         out = out * std + mean
         out = out.to(device="cpu", dtype=orig_dtype).contiguous()
     finally:

--- a/director/refine_pack.py
+++ b/director/refine_pack.py
@@ -279,6 +279,7 @@ def pack_refine(
     sampler: str = "",
     sigmas=None,
     confirm_first_pass: bool = False,
+    enable_chunking: bool = True,
 ) -> dict[str, Any]:
     mode = str(mode or "refine").strip().lower()
     if mode not in REFINE_MODES:
@@ -330,6 +331,7 @@ def pack_refine(
         "sigmas_tensor": sigma_tensor,
         "has_sigmas_tensor": sigma_tensor is not None,
         "confirm_first_pass": bool(confirm_first_pass),
+        "enable_chunking": bool(enable_chunking),
     }
 
 
@@ -414,6 +416,7 @@ def normalize_refine_pack(
         "sigmas_tensor": sigma_tensor,
         "has_sigmas_tensor": sigma_tensor is not None,
         "confirm_first_pass": bool(raw.get("confirm_first_pass", False)),
+        "enable_chunking": bool(raw.get("enable_chunking", True)),
     }
 
 
@@ -477,6 +480,7 @@ def refine_fingerprint(plan) -> dict[str, Any]:
         "refine_sigmas_wired": bool(pack.get("has_sigmas_tensor") or pack.get("sigmas_tensor") is not None),
         "refine_sample_model": bool(pack.get("has_sample_model") or pack.get("sample_model") is not None),
         "refine_skip_fl2v": bool(pack.get("skip_fl2v", True)),
+        "refine_enable_chunking": bool(pack.get("enable_chunking", True)),
     }
 
 

--- a/director/refine_sampling.py
+++ b/director/refine_sampling.py
@@ -357,6 +357,7 @@ def _apply_h3_latent_upscale(
         source_height=src_h,
         model_name=model_name,
         model=latent_mod,
+        enable_chunking=bool(pack.get("enable_chunking", True)),
     )
     if isinstance(encoded, dict):
         encoded.pop("noise_mask", None)

--- a/nodes/director_refine.py
+++ b/nodes/director_refine.py
@@ -204,6 +204,18 @@ class MiniMaxH3DirectorRefine:
                         ),
                     },
                 ),
+                "enable_chunking": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": (
+                            "H3 latent 放大的时间分块（省显存）。"
+                            "latent 超过 24 帧时按 24 帧切块、首尾各垫 5 帧重叠加权融合，"
+                            "显存峰值被封顶，长视频不易爆显存；≤24 帧自动走整段，无差异。"
+                            "关掉则整段一次前向（与旧版行为一致，吃显存）。"
+                        ),
+                    },
+                ),
             },
         }
 
@@ -242,6 +254,7 @@ class MiniMaxH3DirectorRefine:
         height=720,
         skip_fl2v=True,
         confirm_first_pass=False,
+        enable_chunking=True,
         latent_upscale_model=None,
         upscale_model=None,
         h3_latent_model="",
@@ -289,6 +302,7 @@ class MiniMaxH3DirectorRefine:
             target_height=target_height,
             skip_fl2v=skip_fl2v,
             confirm_first_pass=bool(confirm_first_pass),
+            enable_chunking=bool(enable_chunking),
             upscale_method=upscale_method,
             sample_model=refine_model if refine_model is not None else model,
             latent_upscale_model=latent_upscale_model if latent_upscale_model is not None else h3_latent_model,

--- a/web/js/minimax_refine.js
+++ b/web/js/minimax_refine.js
@@ -498,6 +498,7 @@ function syncRefineWidgetVisibility(node) {
     const showH3Model = latentOnly || (upscale && method === "h3_latent");
     setWidgetVisible(node, "upscale_method", upscale);
     setWidgetVisible(node, "latent_upscale_model", showH3Model);
+    setWidgetVisible(node, "enable_chunking", showH3Model);
     setWidgetVisible(node, "h3_latent_model", false);
     setWidgetVisible(node, "upscale_model", false);
     setWidgetVisible(node, "schedule", false);


### PR DESCRIPTION
改动概述
为 MiniMaxH3DirectorRefine 节点增加分块（chunking）支持，将长序列沿时间维切分处理，有效降低显存峰值，使8G显存用户可稳定运行 Refine 二采。

具体改动
- director/h3_latent_upscale.py：实现 _forward_seg 分块调度，支持 overlap 自动探测、重叠区线性加权融合；
- nodes/director_refine.py：新增 enable_chunking 布尔控件（默认开启）；
- director/refine_pack.py：透传分块参数至 pack，指纹中记录 refine_enable_chunking；
- director/refine_sampling.py：从 pack 读取参数并传递给放大函数；
- web/js/minimax_refine.js：控件联动显隐，仅在 h3_latent 模式下展示。

兼容性
- 默认开启，不影响老工作流；
- 在不启用放大或使用其他放大模式时控件自动隐藏。