### PR TITLE
feat: 一采缓存检查识别外接组（接线指纹 + 逐段独立判定）

### DIFF
--- a/director/external_groups.py
+++ b/director/external_groups.py
@@ -36,6 +36,131 @@ MMX_DIR_GROUPS = MMX_DIR_GROUP
 I2V_FAMILY = frozenset({"t2v", "i2v", "fl2v"})
 R2V_FAMILY = frozenset({"r2v"})
 
+# timeline_data key carrying the frontend "which graph is wired into the group
+# input" witness (web/js/minimax_external_witness.js). It is stored in the
+# first-pass cache fingerprint so the cache-status panel can detect wiring
+# changes it cannot recompute from widget values alone.
+EXTERNAL_WITNESS_KEY = "externalGroupsWitness"
+_WITNESS_STR_MAX = 120
+# Named buckets of the witness, used to say *what* changed instead of "外接组".
+WITNESS_FACETS = ("wiring", "prompt", "length", "media", "other", "timeline")
+# Group records are capped frontend-side too; this only guards against a hand
+# crafted payload.
+_WITNESS_MAX_GROUPS = 256
+
+
+def _normalize_witness_facets(raw: Any) -> dict[str, str] | None:
+    if not isinstance(raw, dict):
+        return None
+    facets: dict[str, str] = {}
+    for name in WITNESS_FACETS:
+        value = raw.get(name)
+        if value is None:
+            continue
+        facets[name] = str(value).strip()[:_WITNESS_STR_MAX]
+    return facets or None
+
+
+def normalize_external_group_record(raw: Any) -> dict[str, Any] | None:
+    """One witness record per graph-wired group (= one segment / cache slot).
+
+    ``dur`` is the group's own duration in seconds: the cache panel derives the
+    segment's frame count from it exactly like the run does. ``prompt``/``sub``
+    are digests; ``facets`` labels which bucket changed.
+    """
+    if not isinstance(raw, dict):
+        return None
+    record: dict[str, Any] = {
+        "slot": str(raw.get("slot") or "").strip()[:_WITNESS_STR_MAX],
+        "node": str(raw.get("node") or "").strip()[:_WITNESS_STR_MAX],
+        "prompt": str(raw.get("prompt") or "").strip()[:_WITNESS_STR_MAX],
+        "sub": str(raw.get("sub") or "").strip()[:_WITNESS_STR_MAX],
+    }
+    dur = raw.get("dur")
+    if dur is not None:
+        try:
+            record["dur"] = round(float(dur), 6)
+        except (TypeError, ValueError):
+            record["dur"] = None
+    else:
+        record["dur"] = None
+    facets = _normalize_witness_facets(raw.get("facets"))
+    if facets:
+        record["facets"] = facets
+    return record
+
+
+def normalize_external_witness(raw: Any) -> dict[str, Any] | None:
+    """Normalize the frontend external-group witness (``None`` when absent).
+
+    The witness rides inside ``timeline_data`` — the only value the cache-status
+    route and the Director execute path both receive. It is a change-detection
+    token, not user data, hence the narrow, versioned shape.
+
+    ``facets`` (wiring / prompt / length / media / other / timeline) and
+    ``groups`` are optional: older frontends and caches only carry the aggregate
+    ``graph`` digest, in which case the panel reports the category it *can* still
+    name, or nothing.
+    """
+    if not isinstance(raw, dict):
+        return None
+    graph = str(raw.get("graph") or raw.get("digest") or "").strip()[:_WITNESS_STR_MAX]
+    if not graph:
+        return None
+
+    def _text(key: str) -> str:
+        return str(raw.get(key) or "").strip()[:_WITNESS_STR_MAX]
+
+    def _int(key: str, fallback: int) -> int:
+        try:
+            return int(raw.get(key))
+        except (TypeError, ValueError):
+            return fallback
+
+    out: dict[str, Any] = {
+        "v": _int("v", 1),
+        "port": _text("port"),
+        "source": _text("source"),
+        "nodes": _int("nodes", 0),
+        "graph": graph,
+        "timeline": _text("timeline"),
+    }
+    fps = raw.get("fps")
+    if fps is not None:
+        try:
+            fps_value = float(fps)
+        except (TypeError, ValueError):
+            fps_value = None
+        if fps_value and fps_value > 0:
+            out["fps"] = round(fps_value, 6)
+    raw_groups = raw.get("groups")
+    if isinstance(raw_groups, list):
+        groups = [
+            record
+            for record in (
+                normalize_external_group_record(item)
+                for item in raw_groups[:_WITNESS_MAX_GROUPS]
+            )
+            if record is not None
+        ]
+        if groups:
+            out["groups"] = groups
+    # 「选择运行」selection, mirrored by the panel to report the same selected split.
+    raw_sel = raw.get("sel")
+    if isinstance(raw_sel, dict) and raw_sel.get("on") and isinstance(raw_sel.get("idx"), list):
+        picked: list[int] = []
+        for item in raw_sel["idx"][:_WITNESS_MAX_GROUPS]:
+            try:
+                picked.append(int(item))
+            except (TypeError, ValueError):
+                continue
+        if picked:
+            out["sel"] = {"on": True, "idx": picked}
+    facets = _normalize_witness_facets(raw.get("facets"))
+    if facets:
+        out["facets"] = facets
+    return out
+
 
 def _as_image_batch(image: Any) -> torch.Tensor | None:
     if image is None:
@@ -339,6 +464,27 @@ def validate_external_group_inputs(
     return task_key, r2v, "r2v"
 
 
+def external_witness_from_timeline(timeline: Any) -> dict[str, Any] | None:
+    if not isinstance(timeline, dict):
+        return None
+    return normalize_external_witness(timeline.get(EXTERNAL_WITNESS_KEY))
+
+
+def external_witness_from_timeline_data(timeline_data: Any) -> dict[str, Any] | None:
+    """Witness out of a raw ``timeline_data`` widget value (JSON text or dict)."""
+    import json
+
+    if isinstance(timeline_data, dict):
+        return external_witness_from_timeline(timeline_data)
+    text = str(timeline_data or "")
+    if not text.strip():
+        return None
+    try:
+        return external_witness_from_timeline(json.loads(text))
+    except Exception:
+        return None
+
+
 def build_plan_from_external_groups(
     groups: list[dict[str, Any]],
     *,
@@ -620,7 +766,7 @@ def build_plan_from_external_groups(
     continuity_redraw = resolve_continuity_redraw(timeline)
     continuity_keep_tail = resolve_continuity_keep_tail(timeline)
 
-    return DirectorPlan(
+    plan = DirectorPlan(
         frame_rate=fps,
         total_frames=total or int(total_frames or 0),
         width=out_w,
@@ -646,3 +792,7 @@ def build_plan_from_external_groups(
         continuity_keep_tail=continuity_keep_tail,
         global_ref_audios=list(common_audios_raw) if family == "r2v" else [],
     )
+    # Stamp the wiring witness so the first-pass cache records which graph
+    # produced these segments (the cache-status panel compares against it).
+    plan.external_groups_witness = external_witness_from_timeline(timeline)
+    return plan

--- a/director/http_routes.py
+++ b/director/http_routes.py
@@ -530,6 +530,7 @@ async def minimax_first_pass_cache_status(request):
     if isinstance(timeline_data, dict):
         timeline_data = json.dumps(timeline_data, ensure_ascii=False)
     try:
+        from .external_groups import external_witness_from_timeline_data
         from .plan import build_director_plan
         from .segment_cache import inspect_first_pass_cache
 
@@ -551,7 +552,14 @@ async def minimax_first_pass_cache_status(request):
         plan.sample_sigmas_linked = bool(body.get("sigmas_linked"))
         plan.sample_shift_video = float(body.get("shift_video") or 12.0)
         plan.sample_shift_audio = float(body.get("shift_audio") or 3.0)
-        return web.json_response(inspect_first_pass_cache(node_id, plan))
+        # Graph-wired i2v_groups / r2v_groups never reach this route as values,
+        # so the panel ships a witness of that wiring inside timeline_data.
+        witness = external_witness_from_timeline_data(timeline_data)
+        if witness:
+            plan.external_groups_witness = witness
+        return web.json_response(
+            inspect_first_pass_cache(node_id, plan, external_groups=witness)
+        )
     except Exception as exc:
         log.warning("MiniMax H3 Director first-pass cache inspection failed: %s", exc)
         return web.json_response(

--- a/director/plan.py
+++ b/director/plan.py
@@ -300,6 +300,11 @@ class DirectorPlan:
     sample_sigmas_linked: bool = False
     sample_shift_video: float = 12.0
     sample_shift_audio: float = 3.0
+    # Frontend witness of the graph-wired external groups (i2v_groups /
+    # r2v_groups). Those inputs arrive as tensors at execute time, so the
+    # cache-status panel cannot rebuild the segments from widget values; it
+    # compares this witness instead. See director/external_groups.py.
+    external_groups_witness: dict | None = None
     # Set during execute when export_mode=segments (minimax_seg_export folder).
     segment_mp4_run_dir: str | None = None
 

--- a/director/segment_cache.py
+++ b/director/segment_cache.py
@@ -26,6 +26,46 @@ log = logging.getLogger("ComfyUI-MiniMaxH3-Director.director.cache")
 
 SOURCE_VIDEO_FP_KEY = "source_video"
 
+# External-group (graph-wired i2v_groups / r2v_groups) identity. Stamped by
+# build_plan_from_external_groups from the frontend wiring witness's per-group
+# record — one group = one segment = one cache slot.
+#
+# Only the segment's **own** record is stored, never the whole chain: a segment is
+# reused on its own identity, so editing group_1 leaves group_0's cache alone.
+# The chain itself lives in ``timeline_data`` (status request and execute both
+# receive it) and is never persisted.
+EXTERNAL_SEGMENT_FP_KEY = "external_group"
+
+# Fingerprint keys that come out of the executed group payloads (prompts,
+# durations, reference counts/slots, per-row continuity). The cache-status panel
+# cannot rebuild them for graph-wired groups, so in external-group mode it
+# compares only the remaining keys plus the wiring witness.
+GROUP_DERIVED_FP_KEYS = frozenset(
+    {
+        "index",
+        "start",
+        "end",
+        "prompt",
+        "negative",
+        "task_key",
+        "refs",
+        "ref_audios",
+        "ref_videos",
+        "ref_video",
+        "ref_video_start",
+        "continuity_from_prev",
+        "ref_image_size",
+        SOURCE_VIDEO_FP_KEY,
+    }
+)
+
+
+def has_external_marker(stored: Any) -> bool:
+    """Whether this cache was written from a graph-wired external-group plan."""
+    if not isinstance(stored, dict):
+        return False
+    return EXTERNAL_SEGMENT_FP_KEY in stored
+
 
 def source_video_identity(plan: DirectorPlan) -> list[str]:
     """Stable source-clip identity: relative path + size + mtime (overwrite-safe)."""
@@ -172,6 +212,18 @@ def _segment_identity_fingerprint(seg: SegmentPlan, plan: DirectorPlan) -> dict[
     }
     if plan.continuity_enabled and bool(getattr(plan, "continuity_keep_tail", True)):
         payload["continuity_keep_tail"] = True
+    witness = getattr(plan, "external_groups_witness", None)
+    if isinstance(witness, dict):
+        # This segment's own group only. The whole chain is deliberately *not*
+        # folded in: a segment is reused on its own identity, so editing one
+        # group must not invalidate the others (it would also make the panel
+        # report every segment as mismatched).
+        groups = witness.get("groups")
+        index = int(getattr(seg, "index", 0) or 0)
+        if isinstance(groups, list) and 0 <= index < len(groups):
+            record = groups[index]
+            if isinstance(record, dict):
+                payload[EXTERNAL_SEGMENT_FP_KEY] = record
     return payload
 
 
@@ -872,16 +924,390 @@ def first_pass_cache_disk_signature(node_id: str | None) -> str:
     return "|".join(parts)
 
 
+def _comparable_first_pass_fingerprint(plan: DirectorPlan) -> dict[str, Any]:
+    """First-pass keys that do not depend on the executed group payloads.
+
+    Built from the real fingerprint function so the panel compares exactly what
+    the run writes; group-derived keys are dropped because the panel only has
+    widget values (see ``GROUP_DERIVED_FP_KEYS``).
+    """
+    probe = SegmentPlan(
+        index=0,
+        start_frame=0,
+        end_frame=0,
+        prompt="",
+        task_type="",
+        task_key="",
+        use_global=False,
+    )
+    try:
+        fp = first_pass_cache_fingerprint(probe, plan)
+    except Exception:
+        return {}
+    return {key: value for key, value in fp.items() if key not in GROUP_DERIVED_FP_KEYS}
+
+
+_PRE_META_NAME_RE = re.compile(r"^seg_(\d+)\.pre\.meta\.json$")
+_FINAL_FRAMES_NAME_RE = re.compile(r"^seg_\d+\.pt$")
+
+# Buckets of a group record's digest. Only used to *name* the change: the
+# per-group record is compared as a whole (that is what makes one group's edit
+# invalidate that group's segment alone), and these labels say which part of it
+# moved. ``timeline`` is skipped because timeline-level knobs are plan-wide and
+# are compared through the fingerprint itself.
+_WITNESS_FACET_DIFF_KEYS = {
+    "wiring": "external_wiring",
+    "prompt": "external_prompt",
+    "length": "external_length",
+    "media": "external_media",
+    "other": "external_other",
+    "timeline": "external_timeline",
+}
+
+
+def _external_witness_fps(witness: Any, plan: DirectorPlan) -> float:
+    """Frame rate the run uses: the timeline's, then the Director widget."""
+    if not isinstance(witness, dict):
+        witness = {}
+    try:
+        fps = float(witness.get("fps"))
+    except (TypeError, ValueError):
+        fps = 0.0
+    if not fps or fps <= 0:
+        try:
+            fps = float(getattr(plan, "frame_rate", 0) or 0)
+        except (TypeError, ValueError):
+            fps = 0.0
+    return max(1.0, fps or 24.0)
+
+
+def _external_group_seconds(duration_sec: Any) -> float:
+    """Effective clip duration: the group's own value, else the packer default."""
+    from .fl2v_timeline import DEFAULT_FL2V_DURATION_SEC
+
+    try:
+        seconds = float(duration_sec)
+    except (TypeError, ValueError):
+        seconds = 0.0
+    return seconds if seconds else float(DEFAULT_FL2V_DURATION_SEC)
+
+
+def _external_group_frames(duration_sec: Any, fps: float) -> int:
+    """Frame count of one group — the maths ``build_plan_from_external_groups``
+    applies to that group's ``duration_sec`` when it turns groups into segments."""
+    from .fl2v_timeline import MIN_FL2V_FRAMES, _duration_to_minimax_frames
+    from .frame_align import minimax_align_frame_count
+
+    return int(
+        minimax_align_frame_count(
+            max(
+                MIN_FL2V_FRAMES,
+                _duration_to_minimax_frames(_external_group_seconds(duration_sec), fps),
+            )
+        )
+    )
+
+
+def _external_group_timings(groups: list[Any], fps: float) -> list[dict[str, Any]]:
+    """Per-group `{duration, frames, start, end}` in run order (cumulative)."""
+    timings: list[dict[str, Any]] = []
+    cursor = 0
+    for record in groups:
+        raw_duration = record.get("dur") if isinstance(record, dict) else None
+        duration = _external_group_seconds(raw_duration)
+        frames = _external_group_frames(raw_duration, fps)
+        start, end = cursor, cursor + frames
+        cursor = end
+        timings.append(
+            {
+                "duration": round(duration, 3),
+                "frames": frames,
+                "start": start,
+                "end": end,
+            }
+        )
+    return timings
+
+
+def _external_selected_indices(
+    witness: dict[str, Any],
+    count: int,
+) -> frozenset[int] | None:
+    """「选择运行」selection out of the witness, using the run's own parser."""
+    sel = witness.get("sel")
+    if not isinstance(sel, dict) or not sel.get("on"):
+        return None
+    idx = sel.get("idx")
+    if not isinstance(idx, list) or not idx or count <= 0:
+        return None
+    from .plan import _parse_run_selection
+
+    try:
+        return _parse_run_selection({"runSelectEnabled": True, "runSelection": idx}, count)
+    except Exception:
+        return None
+
+
+def _external_segment_diff(stored_record: Any, expected_record: Any) -> list[str]:
+    """Name what changed inside **this** segment's own group record.
+
+    The record itself is the identity (the run compares it as a whole), so the
+    caller already knows it differs; this only turns that into a label. The
+    explicit fields come first — the prompt digest and the duration — because they
+    are what users actually edit; the facet digests then say whether it was
+    reference media, wiring or something else. Anything that differs only in a
+    part with no bucket (the node was swapped for another with the same widgets)
+    reports the generic wiring key instead of guessing.
+    """
+    if not isinstance(stored_record, dict) or not isinstance(expected_record, dict):
+        return []
+    keys: list[str] = []
+    if stored_record.get("prompt") != expected_record.get("prompt"):
+        keys.append("external_prompt")
+    if stored_record.get("dur") != expected_record.get("dur"):
+        keys.append("external_length")
+    stored_facets = stored_record.get("facets")
+    expected_facets = expected_record.get("facets")
+    for facet, diff_key in _WITNESS_FACET_DIFF_KEYS.items():
+        if facet == "timeline" or diff_key in keys:
+            continue
+        if not isinstance(stored_facets, dict) or not isinstance(expected_facets, dict):
+            continue
+        if stored_facets.get(facet) != expected_facets.get(facet):
+            keys.append(diff_key)
+    return keys or ["external_wiring"]
+
+
+def _count_final_segment_files(root: Path) -> int:
+    """Number of ``seg_XXXX.pt`` (final render) files; never raises."""
+    if not root.is_dir():
+        return 0
+    try:
+        return sum(
+            1
+            for path in root.glob("seg_*.pt")
+            if _FINAL_FRAMES_NAME_RE.match(path.name)
+        )
+    except OSError:
+        return 0
+
+
+def _inspect_external_group_cache(
+    node_id: str | None,
+    plan: DirectorPlan,
+    witness: dict[str, Any],
+) -> dict[str, Any]:
+    """Cache status for graph-wired external groups.
+
+    ``i2v_groups`` / ``r2v_groups`` arrive as tensors at execute time, so the
+    panel cannot rebuild the executed segments from widget values. Per segment it
+    therefore compares the plan-level sampling knobs it *can* see, that segment's
+    own group record and its frame range — the same set the run uses, which keeps
+    one group's edit from reporting every other group as changed.
+
+    One group = one segment = one cache slot, so the segments are enumerated from
+    the witness's group list — the same order the run uses — rather than from the
+    UI timeline, whose cards external groups override.
+    """
+    result: dict[str, Any] = {
+        "exists": False,
+        "matches": False,
+        "current_seed": int(getattr(plan, "sample_seed", 0) or 0),
+        "cached_seeds": [],
+        "segment_total": 0,
+        "cached_count": 0,
+        "matched_count": 0,
+        "selected_total": 0,
+        "selected_cached": 0,
+        "selected_matched": 0,
+        "final_cached_count": 0,
+        "diff_keys": [],
+        "segments": [],
+        "mode": "external_groups",
+        "external": dict(witness),
+        "unverified_count": 0,
+    }
+    if not node_id:
+        return result
+
+    root = Path(folder_paths.get_output_directory()) / "minimax_seg_cache" / str(node_id)
+    result["final_cached_count"] = _count_final_segment_files(root)
+
+    # Plan-level knobs only. The group-derived keys cannot be rebuilt without the
+    # executed payloads, and this segment's own record is compared below as a
+    # whole — that is the per-group identity.
+    expected_knobs = {
+        key: value
+        for key, value in _comparable_first_pass_fingerprint(plan).items()
+        if key != EXTERNAL_SEGMENT_FP_KEY
+    }
+    raw_groups = witness.get("groups")
+    groups = [g for g in raw_groups if isinstance(g, dict)] if isinstance(raw_groups, list) else []
+    timings = _external_group_timings(groups, _external_witness_fps(witness, plan))
+    local_slots = not timings
+    if timings:
+        result["segment_total"] = len(timings)
+        selected = _external_selected_indices(witness, len(timings))
+        indices = list(range(len(timings)))
+    else:
+        # Caches written by an older frontend carry no group list: fall back to
+        # whatever is on disk (the segment count is then unknown).
+        selected = None
+        try:
+            indices = sorted(
+                int(match.group(1))
+                for path in root.glob("seg_*.pre.meta.json")
+                if (match := _PRE_META_NAME_RE.match(path.name))
+            )
+        except OSError:
+            return result
+        result["segment_total"] = len(indices)
+
+    rows: list[dict[str, Any]] = []
+    cached_seeds: set[int] = set()
+    all_diffs: set[str] = set()
+    unverified = 0
+
+    for idx in indices:
+        timing = timings[idx] if idx < len(timings) else {}
+        record = groups[idx] if idx < len(groups) else None
+        meta_path = root / f"seg_{idx:04d}.pre.meta.json"
+        latent_path = root / f"seg_{idx:04d}.pre.av.pt"
+        meta_exists = meta_path.is_file()
+        cache_exists = meta_exists and latent_path.is_file()
+        stored: Any = None
+        read_error = ""
+        if meta_exists:
+            try:
+                stored = json.loads(meta_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                read_error = str(exc)
+
+        cached_seed = stored.get("seed") if isinstance(stored, dict) else None
+        try:
+            if cached_seed is not None:
+                cached_seed = int(cached_seed)
+                cached_seeds.add(cached_seed)
+        except (TypeError, ValueError):
+            cached_seed = None
+
+        diff: list[str] = []
+        matches = False
+        stored_record = (
+            stored.get(EXTERNAL_SEGMENT_FP_KEY) if isinstance(stored, dict) else None
+        )
+        if meta_exists and not isinstance(stored, dict):
+            diff = ["<invalid-meta>"]
+            status = "mismatch"
+        elif not isinstance(stored, dict):
+            status = "missing"
+        elif not isinstance(stored_record, dict):
+            # Written before per-group records existed (older revision, or queued
+            # straight through the API): the group's own identity cannot be
+            # checked, and the run re-samples this segment once.
+            status = "unverified"
+            unverified += 1
+        else:
+            diff = [
+                key for key, value in expected_knobs.items() if stored.get(key) != value
+            ]
+            # This segment's own group is the only per-group input to reuse.
+            # A peer group's edit is deliberately invisible here — that is what
+            # keeps one group's cache independent of the others.
+            if isinstance(record, dict) and stored_record != record:
+                diff.extend(_external_segment_diff(stored_record, record))
+            expected_end = timing.get("end")
+            stored_end = stored.get("end")
+            if expected_end is not None and stored_end is not None:
+                try:
+                    if int(stored_end) != int(expected_end):
+                        # This segment's own duration is unchanged but its frame
+                        # range moved: an earlier group got longer/shorter. Segments
+                        # are laid out back to back and each one is conditioned on
+                        # the previous clip's tail, so the range has to shift and
+                        # the segment must be re-sampled — but it is NOT this
+                        # group's duration that changed, so it gets its own label
+                        # instead of blaming「外接组时长」on an untouched group.
+                        own_dur_moved = (
+                            isinstance(stored_record, dict)
+                            and isinstance(record, dict)
+                            and stored_record.get("dur") != record.get("dur")
+                        )
+                        key = "external_length" if own_dur_moved else "external_shift"
+                        if key not in diff:
+                            diff.insert(0, key)
+                except (TypeError, ValueError):
+                    pass
+            matches = bool(cache_exists and not diff)
+            status = "valid" if matches else ("missing" if not cache_exists else "mismatch")
+
+        all_diffs.update(diff)
+        rows.append(
+            {
+                "segment": idx + 1,
+                "index": idx,
+                "slot": str(record.get("slot") or "") if isinstance(record, dict) else "",
+                "node": str(record.get("node") or "") if isinstance(record, dict) else "",
+                "duration": timing.get("duration"),
+                "frames": timing.get("frames"),
+                "start": timing.get("start"),
+                "end": timing.get("end"),
+                "stored_end": stored.get("end") if isinstance(stored, dict) else None,
+                "exists": cache_exists,
+                "matches": matches,
+                "status": status,
+                "selected": selected is None or idx in selected,
+                "cached_seed": cached_seed,
+                "diff_keys": diff,
+                "error": read_error,
+            }
+        )
+
+    cached_count = sum(1 for row in rows if row["exists"])
+    matched_count = sum(1 for row in rows if row["matches"])
+    selected_rows = [row for row in rows if row["selected"]]
+    diff_keys = sorted(all_diffs)
+    result.update(
+        {
+            "exists": cached_count > 0,
+            "matches": bool(rows) and matched_count == len(rows),
+            "cached_seeds": sorted(cached_seeds),
+            "cached_count": cached_count,
+            "matched_count": matched_count,
+            "selected_total": len(selected_rows),
+            "selected_cached": sum(1 for row in selected_rows if row["exists"]),
+            "selected_matched": sum(1 for row in selected_rows if row["matches"]),
+            "diff_keys": diff_keys,
+            "segments": rows,
+            "unverified_count": unverified,
+        }
+    )
+    # Only the group list knows the true segment count; the disk scan does not.
+    if local_slots:
+        result["count_source"] = "cache_files"
+    return result
+
+
 def inspect_first_pass_cache(
     node_id: str | None,
     plan: DirectorPlan,
+    *,
+    external_groups: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Inspect first-pass cache files without loading their tensor payloads.
 
     Always walks the whole timeline so「选择运行」unselected slots stay visible.
     ``final_cached_count`` is file presence only (``seg_XXXX.pt``), not a
     fingerprint match — Refine knobs are not on this status request.
+
+    ``external_groups``: wiring witness of graph-wired ``i2v_groups`` /
+    ``r2v_groups``. When present the group-derived keys cannot be rebuilt from
+    widget values, so per segment only the plan-level knobs, that segment's own
+    group record and its frame range are compared.
     """
+    if external_groups:
+        return _inspect_external_group_cache(node_id, plan, external_groups)
+
     current_seed = int(getattr(plan, "sample_seed", 0) or 0)
     result: dict[str, Any] = {
         "exists": False,
@@ -897,6 +1323,8 @@ def inspect_first_pass_cache(
         "final_cached_count": 0,
         "diff_keys": [],
         "segments": [],
+        "mode": "timeline",
+        "stale_external_count": 0,
     }
     if not node_id:
         return result
@@ -911,6 +1339,7 @@ def inspect_first_pass_cache(
     all_diffs: set[str] = set()
     rows: list[dict[str, Any]] = []
     final_cached = 0
+    stale_external = 0
     for seg in all_segments:
         is_selected = selected_set is None or int(seg.index) in selected_set
         idx = int(seg.index)
@@ -935,12 +1364,24 @@ def inspect_first_pass_cache(
         if getattr(plan, "sample_sigmas_linked", False) and isinstance(stored, dict):
             stored_cmp = {k: v for k, v in stored.items() if k != "sigmas"}
             expected_cmp = {k: v for k, v in expected.items() if k != "sigmas"}
-        matches = bool(cache_exists and isinstance(stored, dict) and stored_cmp == expected_cmp)
-        diff = (
-            _fingerprint_diff_keys(stored_cmp, expected_cmp)
-            if isinstance(stored, dict)
-            else (["<invalid-meta>"] if meta_exists else ["<missing-cache>"])
+        matches = bool(
+            cache_exists
+            and isinstance(stored, dict)
+            and stored_cmp == expected_cmp
         )
+        # A row stamped with an external-group witness was written by a group
+        # run, while this request has no group input at all (link removed, or a
+        # queued/API submit). Such a row can never be reused, and the UI-card
+        # diffs below would be noise — the group prompt / duration / reference
+        # media never lived on the card. Report the wiring change only.
+        stale_external_row = has_external_marker(stored)
+        if stale_external_row:
+            diff = ["external_groups_off"]
+            stale_external += 1
+        elif isinstance(stored, dict):
+            diff = _fingerprint_diff_keys(stored_cmp, expected_cmp)
+        else:
+            diff = ["<invalid-meta>"] if meta_exists else ["<missing-cache>"]
         if not cache_exists:
             status = "missing"
         elif matches:
@@ -986,6 +1427,7 @@ def inspect_first_pass_cache(
             "final_cached_count": final_cached,
             "diff_keys": sorted(all_diffs),
             "segments": rows,
+            "stale_external_count": stale_external,
         }
     )
     return result

--- a/web/js/minimax_external_witness.js
+++ b/web/js/minimax_external_witness.js
@@ -1,0 +1,524 @@
+/**
+ * External Director Group witness — what the first-pass cache panel can see.
+ *
+ * `i2v_groups` / `r2v_groups` reach the Director as tensors at execute time, so
+ * the cache-status request (which only carries Director widget values) cannot
+ * rebuild the executed segments. Without a witness it rebuilt the expected
+ * fingerprint from the UI timeline — where external-group prompts, durations
+ * and reference media never live — and therefore always reported 不匹配.
+ *
+ * The witness digests
+ *   1. every node upstream of the connected group input (id, class, bypass
+ *      mode, live widget values) plus the link topology between them,
+ *   2. the plan-relevant subset of the timeline payload, and
+ *   3. one record per graph-wired group (= one segment = one cache slot),
+ * and travels inside `timeline_data`. That widget is already sent both by the
+ * cache-status panel and by the Director node at execute time, so both sides
+ * compare the very same value: any wiring change (prompt, duration, ref slot,
+ * reference file, node bypass) invalidates the cached segment.
+ *
+ * `facets` buckets the graph by category — wiring / prompt / length / media /
+ * other, plus the timeline projection — so the panel can name the changed item
+ * ("外接组提示词") instead of listing every key that could have changed. An
+ * upstream node's widgets are bucketed through the input they feed as well, so a
+ * multiline text node whose widget is named `value` still counts as a prompt.
+ * `groups[i]` does the same per segment: `dur` is the group's own duration in
+ * seconds (the panel derives its frame count from it) and `prompt` is a digest
+ * of its resolved prompt text, independent of widget naming.
+ *
+ * Group discovery is delegated to `minimax_timeline.js`
+ * (`setExternalGroupSpecsProvider`), which already walks Combine slots /
+ * reroutes and knows the packer nodes — the witness and the Director UI must
+ * agree on the segment order the run will use.
+ *
+ * Cost: only runs when a group input is connected, walks the group upstream
+ * chain (a handful of nodes) and hashes a few KB — well under a millisecond.
+ */
+
+export const EXTERNAL_WITNESS_KEY = "externalGroupsWitness";
+
+const GROUP_PORTS = ["i2v_groups", "r2v_groups"];
+const WITNESS_VERSION = 4;
+const FACET_NAMES = ["wiring", "prompt", "length", "media", "other"];
+const MAX_NODES = 500;
+const MAX_DEPTH = 48;
+const MAX_GROUPS = 128;
+const MAX_STRING = 400;
+const MAX_ARRAY = 64;
+const MAX_OBJECT_DEPTH = 8;
+
+/**
+ * Timeline keys an external-group run really reads. Deliberately narrow: once
+ * groups are wired in, the UI card's own rows, prompt, duration and total
+ * frames are ignored, so projecting them would invent mismatches for edits that
+ * change nothing. What is left is the row-level state the group path resolves
+ * per segment (`refImageSize`, `continuityFromPrev`), the continuity switch, and —
+ * only when the common block is on — the shared reference media it merges in.
+ */
+const TIMELINE_TOP_KEYS = [
+    "frameRate",
+    "width",
+    "height",
+    "refMaxSize",
+    "continuousReference",
+];
+const TIMELINE_GLOBAL_KEYS = ["commonEnabled", "continuousReference"];
+const TIMELINE_COMMON_KEYS = ["prompt", "refs", "refVideos", "refAudios"];
+const TIMELINE_OUTPUT_KEYS = ["refImageSize"];
+const TIMELINE_ROW_ARRAYS = ["segments"];
+const TIMELINE_ROW_KEYS = ["index", "refImageSize", "continuityFromPrev"];
+
+/**
+ * Widget / input name buckets behind the named facets. Chinese aliases matter:
+ * third-party packers name the duration widget 「时长_秒」 and their media input
+ * 「素材」, which an English-only matcher silently drops into the catch-all.
+ */
+const PROMPT_HINT_RE =
+    /prompt|text|caption|descri|positive|negative|instruct|lyric|tag|note|script|提示词|文本|描述|台词|旁白|字幕/i;
+const LENGTH_HINT_RE =
+    /frame|duration|length|second|sec|time|fps|count|帧|秒|时长|长度/i;
+const MEDIA_HINT_RE =
+    /image|img|picture|photo|video|vid|audio|aud|sound|file|path|media|mask|ref|asset|图片|图像|视频|音频|素材|参考|角色卡/i;
+
+/** Provider installed by minimax_timeline.js (group chain traversal lives there). */
+let groupSpecsProvider = null;
+
+/**
+ * Register the group-chain provider. The callback receives the Director node
+ * and returns `[{slot, node, nodeLabel, durationSec, prompt}]` in run order, or
+ * null when nothing is wired.
+ */
+export function setExternalGroupSpecsProvider(provider) {
+    groupSpecsProvider = typeof provider === "function" ? provider : null;
+}
+
+/** FNV-1a over UTF-16 code units: tiny, dependency free, stable across sessions. */
+function digest32(text) {
+    let hash = 0x811c9dc5;
+    const value = String(text ?? "");
+    for (let i = 0; i < value.length; i += 1) {
+        const code = value.charCodeAt(i);
+        hash ^= code & 0xff;
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+        hash ^= (code >>> 8) & 0xff;
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash.toString(16).padStart(8, "0");
+}
+
+/**
+ * Structural clone with stable ordering. Long strings (base64 previews, whole
+ * prompts) collapse to `#length:digest` so the witness stays small while still
+ * changing whenever the content changes.
+ */
+function stableValue(value, depth = 0) {
+    if (value == null) return null;
+    const type = typeof value;
+    if (type === "number") return Number.isFinite(value) ? value : String(value);
+    if (type === "boolean") return value;
+    if (type === "string") {
+        return value.length > MAX_STRING ? `#${value.length}:${digest32(value)}` : value;
+    }
+    if (type === "bigint") return String(value);
+    if (type === "function" || type === "symbol" || type === "undefined") return null;
+    if (Array.isArray(value)) {
+        const items = value.slice(0, MAX_ARRAY).map((item) => stableValue(item, depth + 1));
+        if (value.length > MAX_ARRAY) items.push(`#more:${value.length}`);
+        return items;
+    }
+    if (depth > MAX_OBJECT_DEPTH) return String(value);
+    const out = {};
+    for (const key of Object.keys(value).sort()) {
+        out[key] = stableValue(value[key], depth + 1);
+    }
+    return out;
+}
+
+function stableStringify(value) {
+    try {
+        return JSON.stringify(stableValue(value));
+    } catch {
+        return "";
+    }
+}
+
+function pickKeys(source, keys) {
+    const out = {};
+    if (!source || typeof source !== "object") return out;
+    for (const key of keys) {
+        if (key in source) out[key] = source[key];
+    }
+    return out;
+}
+
+/** Plan-relevant projection of a timeline payload (witness key excluded). */
+function timelineProjection(timeline) {
+    const out = pickKeys(timeline, TIMELINE_TOP_KEYS);
+    const globalBlock = timeline?.global;
+    out.global = pickKeys(globalBlock, TIMELINE_GLOBAL_KEYS);
+    if (out.global.commonEnabled) {
+        Object.assign(out.global, pickKeys(globalBlock, TIMELINE_COMMON_KEYS));
+    }
+    out.output = pickKeys(timeline?.output, TIMELINE_OUTPUT_KEYS);
+    for (const name of TIMELINE_ROW_ARRAYS) {
+        const rows = timeline?.[name];
+        out[name] = Array.isArray(rows)
+            ? rows.map((row) => (row && typeof row === "object" ? pickKeys(row, TIMELINE_ROW_KEYS) : row))
+            : [];
+    }
+    return out;
+}
+
+function graphOf(node) {
+    return node?.graph
+        ?? globalThis.app?.graph
+        ?? globalThis.app?.canvas?.graph
+        ?? null;
+}
+
+/** Link lookup that tolerates Map / array / plain-object link tables. */
+function linkRecord(graph, linkId) {
+    if (linkId == null || !graph) return null;
+    for (const pool of [graph.links, graph._links]) {
+        if (!pool) continue;
+        let record = null;
+        if (typeof pool.get === "function") {
+            record = pool.get(linkId) ?? pool.get(String(linkId));
+        } else if (Array.isArray(pool)) {
+            record = pool.find((item) => item && String(item.id) === String(linkId));
+        } else {
+            record = pool[linkId] ?? pool[String(linkId)];
+        }
+        if (!record) continue;
+        const originId = record.origin_id ?? record.originId;
+        if (originId == null) return null;
+        return {
+            originId: String(originId),
+            originSlot: record.origin_slot ?? record.originSlot ?? 0,
+        };
+    }
+    return null;
+}
+
+function findNode(graph, id) {
+    const wanted = String(id);
+    if (typeof graph?.getNodeById === "function") {
+        const direct = graph.getNodeById(wanted) ?? graph.getNodeById(Number(wanted));
+        if (direct) return direct;
+    }
+    for (const node of graph?._nodes ?? graph?.nodes ?? []) {
+        if (String(node?.id) === wanted) return node;
+    }
+    return null;
+}
+
+/** Widgets that carry state (skips non-serialized widgets and buttons). */
+function liveWidgets(node) {
+    const out = [];
+    for (const widget of node?.widgets || []) {
+        if (!widget || widget.options?.serialize === false) continue;
+        if (String(widget.type || "").toLowerCase() === "button") continue;
+        out.push(widget);
+    }
+    return out;
+}
+
+/** Live widget values of one node. */
+function widgetDigest(node) {
+    return stableStringify(
+        liveWidgets(node).map((widget) => [String(widget.name ?? ""), stableValue(widget.value)]),
+    );
+}
+
+/**
+ * Which named facet a widget belongs to. Everything that is not a prompt, a
+ * length or reference media lands in "other" so a change is always localizable.
+ */
+function widgetFacet(name) {
+    if (!name) return "other";
+    if (PROMPT_HINT_RE.test(name)) return "prompt";
+    if (LENGTH_HINT_RE.test(name)) return "length";
+    if (MEDIA_HINT_RE.test(name)) return "media";
+    return "other";
+}
+
+/** Which named facet an input link belongs to ("" = wiring). */
+function wireFacet(name) {
+    if (!name) return "";
+    if (PROMPT_HINT_RE.test(name)) return "prompt";
+    if (MEDIA_HINT_RE.test(name)) return "media";
+    return "";
+}
+
+/**
+ * Facet of an input name, or "" when the name says nothing. Used to bucket the
+ * widgets of an *upstream* node by the input it feeds: the text node wired into
+ * `prompt` is very often named `value` (PrimitiveStringMultiline) or `string`,
+ * so its own widget name alone would drop a prompt edit into the catch-all
+ * "other" bucket instead of naming it「外接组提示词」.
+ */
+function facetForName(name) {
+    if (!name) return "";
+    if (PROMPT_HINT_RE.test(name)) return "prompt";
+    if (LENGTH_HINT_RE.test(name)) return "length";
+    if (MEDIA_HINT_RE.test(name)) return "media";
+    return "";
+}
+
+/** Priority when a node is reachable through several inputs at once. */
+const FACET_RANK = { prompt: 3, length: 2, media: 1, "": 0 };
+
+/**
+ * Bucket of one widget. The widget's own name wins; the role of the input the
+ * node feeds is the fallback, so an unknown name is still localizable.
+ */
+function widgetFacetIn(name, role) {
+    const byName = widgetFacet(name);
+    if (byName !== "other" || !role) return byName;
+    return role;
+}
+
+/**
+ * Upstream chain of one node.
+ *
+ * `entries` is the aggregate identity, kept byte-identical to the first version
+ * so witnesses already written into existing caches still compare equal.
+ * `facets` buckets the same information by category for the panel's diff line,
+ * including the widgets of upstream nodes, bucketed through the input they feed.
+ */
+function graphEntries(graph, startNode) {
+    const seen = new Set();
+    const entries = [];
+    const facets = { wiring: [], prompt: [], length: [], media: [], other: [] };
+    // Node id -> facet of the input it feeds. Priority-merged so the result does
+    // not depend on which branch of the walk reaches the node first (a text node
+    // feeding both `medias` and `prompt` is a prompt source).
+    const roles = new Map();
+    const rememberRole = (id, role) => {
+        if (!role) return;
+        const key = `n${id}`;
+        const prev = roles.get(key) || "";
+        if ((FACET_RANK[role] || 0) > (FACET_RANK[prev] || 0)) roles.set(key, role);
+    };
+    const stack = startNode ? [{ node: startNode, depth: 0 }] : [];
+    while (stack.length && entries.length < MAX_NODES) {
+        const { node, depth } = stack.pop();
+        if (!node || depth > MAX_DEPTH) continue;
+        const key = `n${node.id}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const cls = String(node.comfyClass || node.type || "");
+        const label = `${node.id}|${cls}`;
+        const mode = `m${Number(node.mode ?? 0)}`;
+        const wires = [];
+        const plainWires = [];
+        for (const input of node.inputs || []) {
+            if (input?.link == null) continue;
+            const name = String(input.name ?? "");
+            const record = linkRecord(graph, input.link);
+            if (!record) {
+                wires.push(`${name}<missing`);
+                plainWires.push(`${name}<missing`);
+                continue;
+            }
+            const wire = `${name}<${record.originId}:${record.originSlot}`;
+            wires.push(wire);
+            const bucket = wireFacet(name);
+            if (bucket) facets[bucket].push(`${label}|${wire}`);
+            else plainWires.push(wire);
+            const source = findNode(graph, record.originId);
+            if (source) {
+                rememberRole(source.id, facetForName(name));
+                stack.push({ node: source, depth: depth + 1 });
+            }
+        }
+        wires.sort();
+        plainWires.sort();
+        entries.push([
+            String(node.id),
+            cls,
+            mode,
+            wires.join(","),
+            widgetDigest(node),
+        ].join("|"));
+        facets.wiring.push(`${label}|${mode}|${plainWires.join(",")}`);
+        const role = roles.get(key) || "";
+        for (const widget of liveWidgets(node)) {
+            const bucket = widgetFacetIn(String(widget.name ?? ""), role);
+            facets[bucket].push(
+                `${label}|${widget.name}=${stableStringify(stableValue(widget.value))}`,
+            );
+        }
+    }
+    return { entries, facets };
+}
+
+function digestEntries(entries) {
+    return digest32(entries.slice().sort().join("\n"));
+}
+
+function facetDigests(facets) {
+    const out = {};
+    for (const name of FACET_NAMES) {
+        out[name] = digest32((facets?.[name] || []).slice().sort().join("\n"));
+    }
+    return out;
+}
+
+function connectedGroupPort(node) {
+    for (const name of GROUP_PORTS) {
+        const input = (node?.inputs || []).find((item) => String(item?.name) === name);
+        if (input && input.link != null) return { port: name, link: input.link };
+    }
+    return null;
+}
+
+/**
+ * One record per graph-wired group, in the order the Director executes them:
+ * `{slot, node, dur, prompt, sub, facets}`.
+ *
+ * `dur` is the group's own duration in seconds — the cache panel derives the
+ * segment's frame count from it exactly like the backend does. `prompt` is a
+ * digest of the resolved prompt text, so a prompt edit is named even when the
+ * packer names its widget something the facet heuristics do not know.
+ */
+function groupRecords(graph, node) {
+    if (typeof groupSpecsProvider !== "function") return null;
+    let specs = null;
+    try {
+        specs = groupSpecsProvider(node);
+    } catch {
+        return null;
+    }
+    if (!Array.isArray(specs) || !specs.length) return null;
+    return specs.slice(0, MAX_GROUPS).map((spec, index) => {
+        const leaf = spec?.node || null;
+        const dur = Number(spec?.durationSec);
+        const record = {
+            slot: String(spec?.slot || `group_${index}`),
+            node: String(
+                spec?.nodeLabel
+                || (leaf ? `${leaf.id}:${leaf.comfyClass || leaf.type || ""}` : ""),
+            ),
+            dur: Number.isFinite(dur) && dur > 0 ? dur : null,
+            prompt: digest32(stableStringify(String(spec?.prompt ?? ""))),
+        };
+        if (leaf) {
+            const { entries, facets } = graphEntries(graph, leaf);
+            record.sub = digestEntries(entries);
+            record.facets = facetDigests(facets);
+        } else {
+            // Unknown packer: nothing to walk, the slot's own values are all we have.
+            record.sub = digest32(`${record.slot}|${record.dur ?? ""}|${record.prompt}`);
+            record.facets = facetDigests({});
+        }
+        return record;
+    });
+}
+
+/**
+ * Witness for one Director node, or null when no group input is connected.
+ * `graph`/`timeline`/`facets.*` are short digests; they are not meaningful on
+ * their own.
+ */
+export function buildExternalGroupsWitness(node) {
+    const connected = connectedGroupPort(node);
+    if (!connected) return null;
+    const graph = graphOf(node);
+    if (!graph) return null;
+    const record = linkRecord(graph, connected.link);
+    const source = record ? findNode(graph, record.originId) : null;
+    const { entries, facets } = graphEntries(graph, source);
+    if (!entries.length) return null;
+    const witness = {
+        v: WITNESS_VERSION,
+        port: connected.port,
+        source: source ? `${source.id}:${source.comfyClass || source.type || ""}` : "",
+        nodes: entries.length,
+        graph: digestEntries(entries),
+        facets: facetDigests(facets),
+    };
+    const groups = groupRecords(graph, node);
+    if (groups?.length) witness.groups = groups;
+    return witness;
+}
+
+/**
+ * Run selection carried by the timeline payload. Under external groups
+ * 「选择运行」 selects *groups*, so the panel mirrors it to keep the same
+ * selected/total split the run will use.
+ */
+function timelineSelection(timeline) {
+    if (!timeline || typeof timeline !== "object") return null;
+    const on = Boolean(timeline.runSelectEnabled ?? timeline.run_select_enabled);
+    if (!on) return null;
+    const raw = timeline.runSelection ?? timeline.run_selection;
+    if (!Array.isArray(raw)) return null;
+    const idx = raw
+        .slice(0, MAX_ARRAY)
+        .map((value) => Number(value))
+        .filter((value) => Number.isInteger(value) && value >= 0);
+    return idx.length ? { on: true, idx } : null;
+}
+
+/**
+ * Attach or refresh the witness on a timeline payload object (mutates).
+ * A disconnected group input drops any stale witness, so the backend never
+ * mistakes a UI-timeline run for an external-group run.
+ */
+export function attachExternalGroupsWitness(node, timeline) {
+    if (!timeline || typeof timeline !== "object") return timeline;
+    delete timeline[EXTERNAL_WITNESS_KEY];
+    const witness = buildExternalGroupsWitness(node);
+    if (!witness) return timeline;
+    witness.timeline = digest32(stableStringify(timelineProjection(timeline)));
+    if (witness.facets) witness.facets.timeline = witness.timeline;
+    // Segment lengths are derived from the group durations at the same fps the
+    // run will read out of this very payload.
+    const fps = Number(timeline.frameRate);
+    if (Number.isFinite(fps) && fps > 0) witness.fps = fps;
+    const selection = timelineSelection(timeline);
+    if (selection) witness.sel = selection;
+    timeline[EXTERNAL_WITNESS_KEY] = witness;
+    return timeline;
+}
+
+function sameWitness(a, b) {
+    if (!a || !b) return a === b;
+    return a.graph === b.graph
+        && a.timeline === b.timeline
+        && a.port === b.port
+        && a.nodes === b.nodes
+        && a.source === b.source
+        && a.fps === b.fps
+        && stableStringify(a.facets) === stableStringify(b.facets)
+        && stableStringify(a.groups) === stableStringify(b.groups)
+        && stableStringify(a.sel) === stableStringify(b.sel);
+}
+
+/**
+ * Same, for a serialized `timeline_data` string — used by the cache-status
+ * payload and by the widget serializer so both paths send the same witness.
+ * Returns the input unchanged when the value is not a JSON object.
+ */
+export function injectExternalGroupsWitness(node, timelineJson) {
+    if (typeof timelineJson !== "string" || !timelineJson.trim()) return timelineJson;
+    if (!connectedGroupPort(node) && !timelineJson.includes(EXTERNAL_WITNESS_KEY)) {
+        return timelineJson;
+    }
+    let parsed = null;
+    try {
+        parsed = JSON.parse(timelineJson);
+    } catch {
+        return timelineJson;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return timelineJson;
+    const before = parsed[EXTERNAL_WITNESS_KEY];
+    attachExternalGroupsWitness(node, parsed);
+    if (sameWitness(before, parsed[EXTERNAL_WITNESS_KEY])) return timelineJson;
+    try {
+        return JSON.stringify(parsed);
+    } catch {
+        return timelineJson;
+    }
+}

--- a/web/js/minimax_image_batch.js
+++ b/web/js/minimax_image_batch.js
@@ -395,7 +395,15 @@ function flushBatchDurationInputs(editor) {
     flushBatchPromptInputs(editor);
     const taskKey = resolveTaskKey(editor.getTaskKey?.() || editor.taskTypeWidget?.value);
     if (!isVideoBatchTask(taskKey)) return;
+    // With external groups connected the card's seconds field is a read-only
+    // mirror of the group node — the graph is the source of truth. Flushing it
+    // would write the value rendered *before* the group edit back over the
+    // duration `syncExternalGroupsTimeline` just rebuilt, so the panel would keep
+    // showing the old length (only for the segments whose card is in the DOM).
+    if (editor.hasExternalI2vGroups?.() || editor.hasExternalR2vGroups?.()) return;
     for (const input of list.querySelectorAll("input[data-batch-sec-index]")) {
+        // A disabled/readOnly control is a mirror: never write it back anywhere.
+        if (input.disabled || input.readOnly) continue;
         const live = liveBatchSegmentFromEl(editor, input, "data-batch-sec-index");
         if (!live?.seg) continue;
         clearTimeout(input._t);

--- a/web/js/minimax_refine.js
+++ b/web/js/minimax_refine.js
@@ -7,6 +7,7 @@ import {
     resolutionFromSelector,
     snapResolutionDim,
 } from "./minimax_gen_timeline.js";
+import { injectExternalGroupsWitness } from "./minimax_external_witness.js";
 
 const REFINE_CLASS = "MiniMaxH3DirectorRefine";
 const DIRECTOR_CLASSES = new Set(["MiniMaxH3Director", "ComfyMiniMaxH3Director"]);
@@ -248,6 +249,77 @@ function directorValue(node, name, fallback) {
     return value == null || value === "" ? fallback : value;
 }
 
+/** Fingerprint key → what the user actually changed. */
+const CACHE_DIFF_LABELS = {
+    seed: "seed",
+    start: "片段起点",
+    end: "片段终点（时间范围变化）",
+    prompt: "提示词",
+    negative: "反向提示词",
+    task_key: "生成模式",
+    width: "宽度",
+    height: "高度",
+    frame_rate: "帧率",
+    output_mode: "输出模式",
+    refs: "参考图片",
+    ref_audios: "参考音频",
+    ref_videos: "参考视频",
+    ref_video: "参考视频",
+    ref_video_start: "参考视频起点",
+    source_video: "源视频",
+    continuity: "段间连续性",
+    continuity_overlap: "上下文帧数",
+    continuity_mode: "引导方式",
+    continuity_redraw: "重绘幅度",
+    continuity_keep_tail: "保完整",
+    cfg: "CFG",
+    steps: "一采步数",
+    sampler: "一采采样器",
+    scheduler: "调度器",
+    sigmas: "一采噪声表",
+    sigmas_source: "一采 SIGMAS 接线",
+    shift_video: "视频 shift",
+    shift_audio: "音频 shift",
+    "<invalid-meta>": "缓存信息损坏",
+    external_wiring: "外接组接线",
+    external_prompt: "外接组提示词",
+    external_length: "外接组时长",
+    external_shift: "外接组时间轴推移",
+    external_media: "外接组参考素材",
+    external_other: "外接组其他参数",
+    external_groups_off: "外接组（缓存写入后接线已断开）",
+};
+
+function diffLabel(key) {
+    return CACHE_DIFF_LABELS[key] || key;
+}
+
+/**
+ * One compact line naming the segments that cannot be reused. 1 group = 1
+ * segment = 1 cache slot, and a segment is compared against its own group only,
+ * so an edit to one group leaves the others matching — listing every segment
+ * would bury that (and the rest of the panel) under a dozen lines.
+ */
+function externalMismatchLine(data) {
+    const rows = Array.isArray(data?.segments) ? data.segments : [];
+    const bad = rows.filter((row) => !row?.matches);
+    if (!bad.length) return "";
+    const reasons = (row) => {
+        const keys = (Array.isArray(row?.diff_keys) ? row.diff_keys : [])
+            .filter((key) => key !== "<missing-cache>");
+        return keys.length ? keys.map(diffLabel).join("、") : "无缓存";
+    };
+    if (bad.length === rows.length && rows.length > 1) {
+        const all = [...new Set(bad.flatMap((row) => reasons(row).split("、")))].join("、");
+        return `不匹配：全部 ${rows.length} 段（${all}）`;
+    }
+    const parts = bad.slice(0, 4).map(
+        (row) => `${row?.slot || `第 ${row?.segment} 段`}（${reasons(row)}）`,
+    );
+    if (bad.length > parts.length) parts.push(`…共 ${bad.length} 段`);
+    return `不匹配：${parts.join("、")}`;
+}
+
 function directorHasSigmasLink(node) {
     const inp = (node?.inputs || []).find((i) => String(i.name) === "sigmas");
     if (!inp) return false;
@@ -263,7 +335,12 @@ function cacheStatusPayload(director) {
     }
     return {
         node_id: String(director.id),
-        timeline_data: String(directorValue(director, "timeline_data", "")),
+        // Keep the graph-wired external-group witness current: the status route
+        // runs on the backend where i2v_groups / r2v_groups links are invisible.
+        timeline_data: injectExternalGroupsWitness(
+            director,
+            String(directorValue(director, "timeline_data", "")),
+        ),
         task_type: String(directorValue(director, "task_type", "")),
         global_prompt: String(directorValue(director, "global_prompt", "")),
         total_frames: Number(directorValue(director, "total_frames", 124)),
@@ -303,38 +380,7 @@ function renderCacheStatus(node, data, kind = "normal") {
     const seeds = Array.isArray(data?.cached_seeds) && data.cached_seeds.length
         ? data.cached_seeds.join(", ")
         : "—";
-    const diffLabels = {
-        seed: "seed",
-        start: "片段起点",
-        end: "片段终点（时间范围变化）",
-        prompt: "提示词",
-        negative: "反向提示词",
-        task_key: "生成模式",
-        width: "宽度",
-        height: "高度",
-        frame_rate: "帧率",
-        output_mode: "输出模式",
-        refs: "参考图片",
-        ref_audios: "参考音频",
-        ref_videos: "参考视频",
-        ref_video: "参考视频",
-        ref_video_start: "参考视频起点",
-        source_video: "源视频",
-        continuity: "段间连续性",
-        continuity_overlap: "上下文帧数",
-        continuity_mode: "引导方式",
-        continuity_redraw: "重绘幅度",
-        continuity_keep_tail: "保完整",
-        cfg: "CFG",
-        steps: "一采步数",
-        sampler: "一采采样器",
-        scheduler: "调度器",
-        sigmas: "一采噪声表",
-        sigmas_source: "一采 SIGMAS 接线",
-        shift_video: "视频 shift",
-        shift_audio: "音频 shift",
-        "<invalid-meta>": "缓存信息损坏",
-    };
+    const diffLabels = CACHE_DIFF_LABELS;
     const diffs = Array.isArray(data?.diff_keys)
         ? data.diff_keys
             .filter((key) => key !== "<missing-cache>")
@@ -353,7 +399,25 @@ function renderCacheStatus(node, data, kind = "normal") {
     lines.push(`当前 seed：${data?.current_seed ?? "—"}`);
     const finalCached = Number(data?.final_cached_count || 0);
     lines.push(`成片缓存：${finalCached}/${total} 段（含音频；部分重跑会接这里）`);
-    if (diffs.length) lines.push(`差异：${diffs.join(", ")}`);
+    if (diffs.length) lines.push(`差异：${diffs.join("、")}`);
+    if (data?.mode === "external_groups") {
+        // External groups are not on the timeline: each segment is compared
+        // against its own group (prompt / duration / its reference slots) plus
+        // the plan-level knobs.
+        lines.push("核对方式：外接组");
+        const mismatch = externalMismatchLine(data);
+        if (mismatch) lines.push(mismatch);
+    }
+    const unverified = Number(data?.unverified_count || 0);
+    if (unverified > 0) {
+        lines.push(`提示：${unverified} 段缓存未记录外接组信息（旧版写入），这些段会重采一次`);
+    }
+    const staleExternal = Number(data?.stale_external_count || 0);
+    if (staleExternal > 0) {
+        lines.push(
+            `提示：${staleExternal} 段缓存由外接组计划写入，当前未检测到外接组接线，这些段会重采一采`,
+        );
+    }
     ui.body.textContent = lines.join("\n");
 }
 

--- a/web/js/minimax_timeline.js
+++ b/web/js/minimax_timeline.js
@@ -113,6 +113,11 @@ import {
     toggleLocale,
 } from "./minimax_i18n.js";
 import { bindPackActions } from "./minimax_pack.js";
+import {
+    attachExternalGroupsWitness,
+    injectExternalGroupsWitness,
+    setExternalGroupSpecsProvider,
+} from "./minimax_external_witness.js";
 
 const RULER_H = 24;
 const SEG_LABEL_H = 20;
@@ -2123,6 +2128,25 @@ class MiniMaxH3DirectorEditor {
         this.heightWidget = this.widget("height");
         this.refMaxWidget = this.widget("ref_max_size");
 
+        // Refresh the external-group witness while the prompt is built, so an
+        // upstream edit made after the last timeline write can never leave a
+        // stale witness in the submitted timeline_data.
+        if (this.timelineWidget && !this.timelineWidget._mmxWitnessSerialized) {
+            const widget = this.timelineWidget;
+            const previous = typeof widget.serializeValue === "function"
+                ? widget.serializeValue
+                : null;
+            widget._mmxWitnessSerialized = true;
+            widget.serializeValue = function (targetNode) {
+                const raw = previous
+                    ? previous.call(widget, targetNode)
+                    : widget.value;
+                return typeof raw === "string"
+                    ? injectExternalGroupsWitness(targetNode ?? node, raw)
+                    : raw;
+            };
+        }
+
         const initTotal = Math.max(0, parseInt(this.totalFramesWidget?.value || 124, 10));
         const initFps = coerceTimelineFps(this.frameRateWidget?.value || 24);
         this.timeline = parseTimeline(this.timelineWidget?.value, initTotal, initFps);
@@ -2723,7 +2747,13 @@ class MiniMaxH3DirectorEditor {
         if (this.isImageBatch?.()) flushBatchPromptInputs(this);
         if (this.isFl2vMode?.()) flushFl2vPromptDraft(this);
         this.syncFromWidgets();
-        this.timelineWidget.value = JSON.stringify(this.buildTimelinePayload());
+        // Graph-wired external groups are invisible to widget-only readers
+        // (cache-status panel / backend at execute time), so ship a witness of
+        // the group wiring inside timeline_data itself. See
+        // minimax_external_witness.js.
+        const payload = this.buildTimelinePayload();
+        attachExternalGroupsWitness(this.node, payload);
+        this.timelineWidget.value = JSON.stringify(payload);
         this.node.setDirtyCanvas(true, false);
     }
 
@@ -12321,6 +12351,53 @@ function patchUpstreamAudioWidgetSync(graph, node, inputName) {
     patchUpstreamWidgetSync(graph, node, inputName, ["audio", "audio_path", "video", "video_path", "file", "filename"]);
 }
 
+/** Widget names that carry a prompt string on upstream text nodes. */
+const PROMPT_SOURCE_WIDGETS = [
+    "prompt", "text", "value", "string", "text_str", "positive_prompt", "content",
+];
+
+/** First non-empty string widget on `node`, by the names above. */
+function readPromptWidgetValue(node) {
+    for (const name of PROMPT_SOURCE_WIDGETS) {
+        const value = nodeWidgetValue(node, name);
+        if (typeof value === "string" && value) return value;
+    }
+    return null;
+}
+
+/**
+ * Text the run will actually receive on this input: follow the link upstream and
+ * read the source node's own string widget, walking through STRING passthroughs
+ * (string concat / reroute-style helpers).
+ */
+function readLinkedPromptText(graph, node, inputName = "prompt", depth = 0) {
+    if (!graph || !node || depth > 8) return null;
+    const src = linkedSourceNode(graph, node, inputName);
+    if (!src) return null;
+    const direct = readPromptWidgetValue(src);
+    if (direct != null) return direct;
+    for (const inp of src.inputs || []) {
+        if (inp?.link == null || String(inp.type || "").toUpperCase() !== "STRING") continue;
+        const up = readLinkedPromptText(graph, src, inp.name, depth + 1);
+        if (up != null) return up;
+    }
+    return null;
+}
+
+/**
+ * Effective prompt of a group. When its `prompt` input is wired, the group's own
+ * widget is empty (the link owns the value) — reading only the widget made every
+ * prompt edit report「外接组其他参数」 instead of「外接组提示词」, and left the
+ * Director card showing an empty prompt.
+ */
+function resolveExternalGroupPrompt(graph, node) {
+    const own = String(nodeWidgetValue(node, "prompt") ?? "");
+    const inp = (node?.inputs || []).find((i) => i?.name === "prompt");
+    if (inp?.link == null) return own;
+    const linked = readLinkedPromptText(graph, node, "prompt");
+    return linked != null ? linked : own;
+}
+
 /** Collect Autogrow / legacy slots matching `(?:^|\.)prefix_(\\d+)$`. */
 function collectAutogrowSlotRefs(graph, node, prefix, resolvePath, toRef, patchSync) {
     const found = new Map();
@@ -12341,12 +12418,15 @@ function collectAutogrowSlotRefs(graph, node, prefix, resolvePath, toRef, patchS
 function readExternalGroupSpec(node, graph = null) {
     const g = graph || app.graph || app.canvas?.graph;
     const durRaw = Number(nodeWidgetValue(node, "duration_sec"));
-    const prompt = String(nodeWidgetValue(node, "prompt") ?? "");
+    const prompt = resolveExternalGroupPrompt(g, node);
     const cls = node?.comfyClass || node?.type || "";
     const firstImageFile = resolveLinkedImageFile(g, node, "first_frame");
     const lastImageFile = resolveLinkedImageFile(g, node, "last_frame");
     patchUpstreamImageWidgetSync(g, node, "first_frame");
     patchUpstreamImageWidgetSync(g, node, "last_frame");
+    // Editing the prompt on the upstream text node must refresh the Director card
+    // (and the cache verdict) just like editing the group's own widget does.
+    patchUpstreamWidgetSync(g, node, "prompt", PROMPT_SOURCE_WIDGETS);
 
     let refImages = [];
     let refVideos = [];
@@ -12436,22 +12516,47 @@ function passthroughUpstreamLinkId(node) {
     return linked.length ? linked[0].link : null;
 }
 
-function expandExternalGroupLink(graph, linkId, depth = 0, mode = "specs") {
+/**
+ * A leaf group packer: one node = one group = one segment. Any node emitting
+ * MMX_DIR_GROUP counts, so a third-party packer gets its real duration/prompt
+ * instead of falling back to a placeholder.
+ */
+function isExternalGroupLeafNode(node) {
+    if (!node) return false;
+    const cls = String(node.comfyClass || node.type || "");
+    if (EXTERNAL_GROUP_NODE_TYPES.has(cls)) return true;
+    return (node.outputs || []).some((o) => String(o?.type || "") === "MMX_DIR_GROUP");
+}
+
+/** A fan-in: takes group slots and re-emits a group list (ours or third-party). */
+function isExternalCombineNode(node) {
+    if (!node) return false;
+    const cls = String(node.comfyClass || node.type || "");
+    if (cls === EXTERNAL_COMBINE_NODE_TYPE) return true;
+    const takesGroups = (node.inputs || []).some(
+        (i) => String(i?.type || "") === "MMX_DIR_GROUP" || combineGroupSlotIndex(i?.name) != null,
+    );
+    const emitsGroup = (node.outputs || []).some(
+        (o) => String(o?.type || "") === "MMX_DIR_GROUP",
+    );
+    return takesGroups && emitsGroup;
+}
+
+function expandExternalGroupLink(graph, linkId, depth = 0, mode = "specs", slotLabel = "") {
     if (linkId == null || depth > 16) return [];
     const rec = graphLinkRecord(graph, linkId);
     if (!rec) return [];
     const node = graph.getNodeById?.(rec.originId);
     if (!node) return [];
-    const cls = node.comfyClass || node.type || "";
 
     // Walk through Reroute / rgthree Reroute / other virtual passthroughs.
     if (isExternalGroupPassthroughNode(node)) {
         const upstream = passthroughUpstreamLinkId(node);
         if (upstream == null) return [];
-        return expandExternalGroupLink(graph, upstream, depth + 1, mode);
+        return expandExternalGroupLink(graph, upstream, depth + 1, mode, slotLabel);
     }
 
-    if (cls === EXTERNAL_COMBINE_NODE_TYPE) {
+    if (isExternalCombineNode(node)) {
         const out = [];
         const slots = (node.inputs || [])
             .filter(isCombineGroupSlot)
@@ -12463,12 +12568,19 @@ function expandExternalGroupLink(graph, linkId, depth = 0, mode = "specs") {
             });
         for (const input of slots) {
             if (input.link == null) continue;
-            out.push(...expandExternalGroupLink(graph, input.link, depth + 1, mode));
+            const label = slotLabel || String(input.name || "");
+            out.push(...expandExternalGroupLink(graph, input.link, depth + 1, mode, label));
         }
         return out;
     }
-    if (EXTERNAL_GROUP_NODE_TYPES.has(cls)) {
-        return mode === "nodes" ? [node] : [readExternalGroupSpec(node, graph)];
+    if (isExternalGroupLeafNode(node)) {
+        if (mode === "nodes") return [node];
+        const spec = readExternalGroupSpec(node, graph);
+        // Kept off the UI fields above: the witness and the panel need the node
+        // itself to digest that group's own subtree.
+        spec.slot = slotLabel || "";
+        spec.groupNode = node;
+        return [spec];
     }
     // Unknown upstream packer — still reserve one slot for run-select/timeline.
     if (mode === "nodes") return [null];
@@ -12480,6 +12592,8 @@ function expandExternalGroupLink(graph, linkId, depth = 0, mode = "specs") {
         lastImageFile: null,
         refImages: [],
         refVideos: [],
+        slot: slotLabel || "",
+        groupNode: null,
         refAudios: [],
     }];
 }
@@ -12512,11 +12626,53 @@ function collectExternalGroupNodes(editor) {
     return nodes.length ? nodes : null;
 }
 
+/** First connected group port on a Director node, or null. */
+function firstConnectedGroupPort(node) {
+    for (const name of ["i2v_groups", "r2v_groups"]) {
+        const inp = (node?.inputs || []).find((i) => String(i?.name) === name);
+        if (inp && inp.link != null) return name;
+    }
+    return null;
+}
+
+/**
+ * Ordered leaf groups of a Director node — the same order the backend runs
+ * (Combine slots sorted by index, reroutes transparent). The first-pass cache
+ * witness borrows this so panel and run always agree on segment count and
+ * per-segment duration.
+ */
+function collectExternalGroupChain(node) {
+    const port = firstConnectedGroupPort(node);
+    if (!port) return null;
+    const graph = app.graph ?? app.canvas?.graph;
+    const inp = (node?.inputs || []).find((i) => String(i?.name) === port);
+    if (!graph || inp?.link == null) return null;
+    const specs = expandExternalGroupLink(graph, inp.link, 0, "specs");
+    if (!specs.length) return null;
+    return specs.map((spec, index) => ({
+        slot: spec.slot || `group_${index}`,
+        node: spec.groupNode || null,
+        nodeLabel: spec.groupNode
+            ? `${spec.groupNode.id}:${spec.groupNode.comfyClass || spec.groupNode.type || ""}`
+            : "",
+        durationSec: spec.durationSec,
+        prompt: spec.prompt,
+    }));
+}
+
+// The cache-status witness needs exactly this chain: one record per group, in
+// run order, with each group's own duration and resolved prompt.
+setExternalGroupSpecsProvider(collectExternalGroupChain);
+
 function notifyDirectorsSyncExternalGroups() {
     const graph = app.graph ?? app.canvas?.graph;
     for (const node of graph?._nodes ?? graph?.nodes ?? []) {
         if (!isMiniMaxH3DirectorNode(node)) continue;
         node._minimaxEditor?.syncExternalGroupsTimeline?.();
+        // The Refine card keeps its own verdict (匹配 / 不匹配); writing the
+        // timeline widget does not fire Director.onWidgetChanged, so ask it to
+        // re-check now that the card has been rebuilt from the edited group.
+        node._mmxRefreshFirstPassCache?.(250);
     }
 }
 
@@ -12705,12 +12861,33 @@ app.registerExtension({
     },
     async beforeRegisterNodeDef(nodeType, nodeData) {
         const cls = nodeType?.comfyClass || nodeData?.name || "";
-        if (EXTERNAL_GROUP_NODE_TYPES.has(cls) || cls === EXTERNAL_COMBINE_NODE_TYPE) {
+        // Any node that can emit a Director group list (our packers, the Combine,
+        // and third-party packers declaring the same socket type).
+        const emitsGroups = Array.isArray(nodeData?.output)
+            && nodeData.output.some((type) => String(type || "").split(",").includes("MMX_DIR_GROUP"));
+        if (EXTERNAL_GROUP_NODE_TYPES.has(cls) || cls === EXTERNAL_COMBINE_NODE_TYPE || emitsGroups) {
             const onConnectionsChange = nodeType.prototype.onConnectionsChange;
             nodeType.prototype.onConnectionsChange = function (...args) {
                 const out = onConnectionsChange?.apply(this, args);
                 // Combine/Group wiring changes do not fire Director.onConnectionsChange.
                 queueMicrotask(() => notifyDirectorsSyncExternalGroups());
+                return out;
+            };
+            const onWidgetChanged = nodeType.prototype.onWidgetChanged;
+            nodeType.prototype.onWidgetChanged = function (name, value, oldValue, widget) {
+                const out = onWidgetChanged?.apply(this, arguments);
+                // Widget values are committed through the value store, which calls
+                // node.onWidgetChanged(name, value, oldValue, widget) for every
+                // widget type — including V3/comfy_api ones, where widget.callback
+                // is not reliably the function the store invokes. Deferred so the
+                // new value is already readable when the card re-reads the group.
+                // `_mmxSkipExternalSync` marks a Director→Group write-through: that
+                // path already synced, so echoing it back would be a wasted round.
+                if (name === "duration_sec" || name === "prompt") {
+                    if (!widget?._mmxSkipExternalSync) {
+                        queueMicrotask(() => notifyDirectorsSyncExternalGroups());
+                    }
+                }
                 return out;
             };
             const onCreated = nodeType.prototype.onNodeCreated;


### PR DESCRIPTION
## 背景

`i2v_groups` / `r2v_groups` 接上外接组后，`MiniMax H3 Director Refine` 面板上的
一采缓存检查会误报不匹配：这两口在 execute 时收到的是 tensor，而状态接口
（`/minimax/director/first_pass_cache_status`）只拿得到 `timeline_data` 与 widget
值，重建不出每段的提示词 / 时长 / 参考素材，于是整段被判成"变了"。

实际困扰：跑完一采什么都没动，重开 ComfyUI 再检查仍显示不匹配。

## 做法

前端生成一枚**接线指纹（witness）**塞进 `timeline_data` 随请求送后端：

- 从组输入口反向遍历上游子图，产出整体摘要，以及**每组一条记录**
  （`slot` / `node` / `dur` / `prompt` / `sub`）和分桶摘要
  （`wiring` / `prompt` / `length` / `media` / `other` / `timeline`）。
- 后端归一化后，把**本段自己那组**的记录折进本段的缓存指纹（`external_group`
  键），检查时逐段比对。
- 差异按桶精确命名，面板显示中文：外接组接线 / 提示词 / 时长 / 参考素材 /
  其他参数 / 时间轴推移。

**逐段独立**：整条链刻意不参与比较 —— 一个 group 对应一段一份缓存，所以改
`group_1` 只让第 2 段失效，`group_0` 的缓存不受影响（新增 group 时只有新段报
missing）。只有**时长前移**会让后续段的 `start` / `end` 平移并连带失效，这是
顺序时间轴本来的语义，面板会写成「外接组时间轴推移」而不是笼统的「时长」。

**第三方 packer 也支持**：叶子 / 扇入组的判定只看输出类型 `MMX_DIR_GROUP`
（`director/external_groups.py` 里已有的常量），不认节点名；任何第三方 packer
只要声明同一 socket 类型即可被识别，读它的 `duration_sec` / `prompt`。

## 影响面

- **未接外接组时行为完全不变**：仍走原时间轴指纹，缓存文件与目录名不变。
- 接了外接组：缓存检查显示「核对方式：外接组」，改动后差异精确到桶。
- 缓存指纹里多了 `external_group` 一个键；旧缓存会一次性报不匹配，重跑一采
  即恢复（判定口径与真跑一致，不会出现"面板说匹配、真跑却重采"）。

## 测试

本地离线回归 211 项全绿：

| 套 | 项数 | 覆盖 |
|---|---|---|
| 前端行为（桩 graph + 真源码求值） | 64 | packer 键名解析、链序 / slot、facets 分桶、逐段独立、断开组清 witness |
| 面板回写 | 5 | 外接组模式下禁用镜像不回写段 |
| 真实工作流回放 | 10 | 读一份含 2 组的 timeline 建图，验证上游文本节点的提示词能被识别且只动提示词桶 |
| 跨语言契约（JS→Py） | 46 + 3 | 字段名一致、面板文案无英文键名 |
| 后端逐段判定 | 75 | 帧数公式、逐段枚举 / 差异命名、计划级旋钮、旧缓存 unverified、选择运行 |
| 前后端帧数一致 | 8 | 卡片公式 vs 后端公式 |

另在本地 ComfyUI 上用一个第三方 packer 节点（2 组 · r2v）实测：改 group 时长
面板段帧数跟随、改上游文本节点报「外接组提示词」、改第一段时长时第二段报
「外接组时间轴推移」。
