### PR TITLE
fix: leave seam untouched for hard-cut segments (per-segment continuity off)

### DIFF
--- a/director/segment_continuity.py
+++ b/director/segment_continuity.py
@@ -1657,14 +1657,25 @@ def concat_continuous_chunks(
 
     Generation settling burn-in handles flash/pulse. Concat RGB morphs are OFF
     (00035: body0/hold→pop caused 拖影 and stutter pulses).
+
+    A segment with ``continuity_from_prev = False`` is an intentional hard cut
+    (a new shot): its seam gets **no** exposure/soften/bridge pass. Otherwise the
+    first frames of the new shot are pulled toward the previous shot's tail
+    brightness, which reads as a visible brightness flash exactly at the cut.
     """
-    del segments
     if not chunks:
         raise ValueError("concat_continuous_chunks: no chunks")
     if not getattr(plan, "continuity_enabled", False) or len(chunks) < 2:
         return cat_frames_variable_size(chunks)
     fixed: list[torch.Tensor] = [chunks[0]]
     for i in range(1, len(chunks)):
+        seg = segments[i] if i < len(segments) else None
+        hard_cut = seg is not None and not bool(
+            getattr(seg, "continuity_from_prev", True)
+        )
+        if hard_cut:
+            fixed.append(chunks[i])
+            continue
         left = _unfreeze_held_tail(fixed[-1])
         if CONTINUITY_HOLD_POP_ON_TAIL:
             left = _break_hold_pop_window(left, from_end=True)

--- a/lib/video_export.py
+++ b/lib/video_export.py
@@ -136,7 +136,7 @@ def write_frames_to_mp4(
             "-pix_fmt",
             "yuv420p",
             "-preset",
-            "veryfast",
+            "medium",
             "-crf",
             "18",
             "-movflags",


### PR DESCRIPTION
## 问题

`Segment continuity`（段间运动上下文）开启后，合并阶段会对**每个**接缝做曝光/柔化/桥接修正
（`concat_continuous_chunks` 里的 `_additive_opening_luma` 等），但它并不区分
「本段引用上段（连续）」与「本段引用上段 = 关（硬切，新场景）」。

结果：硬切段的首帧被强行拉向上一段尾部的亮度，切点处出现**亮度跳变/闪一下**
——新场景的画面被上一场景的亮度「污染」。

（`concat_continuous_chunks` 目前开头就是 `del segments`，段信息在进入循环前被丢弃，
所以函数拿不到任何「本段是否硬切」的信息。）

## 复现

1. 时间轴 6 段，第 6 段「引用上段」关闭（硬切），其余开启；
2. 开启段间连续性，跑完整轮；
3. 合并导出的成片在段 5→6 的切点处，段 6 首帧亮度异常。

实测（6 段 1376×768，段 6 硬切）：

* 第 5 段尾部亮度 ≈ 0.240（稳定）
* 第 6 段前 12 帧：0.221 → 0.135（被强行下压）

日志对应行：`Segment continuity: additive opening luma 12f (seam_gap=0.121 spike=0.001, 0.246→0.127, cap±0.100)`

同一素材在「素材组预览」里单独播放时首帧亮度正常——说明问题出在合并阶段，不在采样。

## 改动

`director/segment_continuity.py`：函数重新使用 `segments` 参数，
`continuity_from_prev = False` 的段（以及索引 0 之外的默认行为不变）
直接拼接、**不做任何接缝加工**。

```python
for i in range(1, len(chunks)):
    seg = segments[i] if i < len(segments) else None
    hard_cut = seg is not None and not bool(
        getattr(seg, "continuity_from_prev", True)
    )
    if hard_cut:
        fixed.append(chunks[i])
        continue
    left = _unfreeze_held_tail(fixed[-1])
    ...
```

连续段（默认 `continuity_from_prev = True`）行为**完全不变**；
`segments` 短于 `chunks` 时按 `seg is None` 走原路径，不改变既有语义。

`Plan` 侧无需改动：`SegmentPlan.continuity_from_prev`（默认 `True`）已由
`resolve_segment_continuity_from_prev()` 填好，`executor_core` 与
`plan.py` 的日志里也已经在用这个字段（`Pin from prev` / `Hard cut (per-segment off)`），
只是合并函数没有消费它。

## 附带：分段 mp4 的 x264 preset

`lib/video_export.py`（分段导出落盘）用 `-preset veryfast`，
在相同 `-crf 18` 下压缩效率低于 ComfyUI 内置 `SaveVideo` 使用的 `medium`：
同码率细节更少、文件更大。改为 `medium`（CPU 成本每段几秒，画质更接近内置档）。

## 验证

* A/B 行为测试（14 帧×3 段，段 3 硬切）：
  * 硬切段输出与输入**逐位相同**（`torch.equal` → True）
  * 对照组（同样素材、段 3 保持连续）输出被修正（max |Δ| = 0.100 = 现有封顶值）
  * 帧数、段数、`segments` 短于 `chunks` 的边界情况均不变
* 真实成片量测：修复前段 5→6 切点亮度 0.240 → 0.221→0.135（下压）；
  修复后该接缝不再进入 luma 分支，段 6 首帧保持素材组预览的原始亮度。

## 兼容性

* 默认行为不变：不关闭「引用上段」的用户感知不到差异；
* 纯合并阶段改动，不触碰采样、pin、二采与缓存指纹。